### PR TITLE
✨ 结构化帮助页 → 图片渲染

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,12 +45,9 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-
-          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-          # queries: security-extended,security-and-quality
+          config: |
+            paths-ignore:
+              - tests
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)

--- a/nonebot_plugin_tetris_stats/games/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/__init__.py
@@ -8,7 +8,7 @@ from nonebot_plugin_alconna import AlcMatches, Alconna, At, CommandMeta, on_alco
 
 from .. import ns
 from ..i18n import Lang
-from ..utils.exception import MessageFormatError, NeedCatchError
+from ..utils.exception import NeedCatchError
 from ..utils.help_extension import HelpImageExtension
 from ..utils.help_formatter import StructuredHelpFormatter
 
@@ -46,11 +46,6 @@ def add_block_handlers(handler: Callable[[T_Handler], T_Handler]) -> None:
 
 
 from . import tetrio, top, tos  # noqa: F401, E402
-
-
-@alc.handle()
-async def _(matcher: Matcher, account: MessageFormatError):
-    await matcher.finish(str(account))
 
 
 @alc.handle()

--- a/nonebot_plugin_tetris_stats/games/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/__init__.py
@@ -9,6 +9,8 @@ from nonebot_plugin_alconna import AlcMatches, Alconna, At, CommandMeta, on_alco
 from .. import ns
 from ..i18n import Lang
 from ..utils.exception import MessageFormatError, NeedCatchError
+from ..utils.help_extension import HelpImageExtension
+from ..utils.help_formatter import StructuredHelpFormatter
 
 command: Alconna = Alconna(
     ['tetris-stats', 'tstats'],
@@ -17,13 +19,22 @@ command: Alconna = Alconna(
         description='俄罗斯方块相关游戏数据查询',
         fuzzy_match=True,
     ),
+    formatter_type=StructuredHelpFormatter,
 )
+# StructuredHelpFormatter needs the root reference to resolve canonical
+# subcommand metadata. Alconna instantiates formatter_type into self.formatter,
+# we just back-fill the root pointer here.
+command.formatter.root = command  # type: ignore[attr-defined]
 
 alc = on_alconna(
     command=command,
     skip_for_unmatch=False,
     auto_send_output=True,
     use_origin=True,
+    # WARNING: only one output_converter Extension may be attached to this
+    # matcher. Future special-output customisation must be merged INTO
+    # HelpImageExtension. See utils/help_extension.py docstring.
+    extensions=[HelpImageExtension()],
 )
 
 

--- a/nonebot_plugin_tetris_stats/games/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/__init__.py
@@ -27,9 +27,6 @@ alc = on_alconna(
     skip_for_unmatch=False,
     auto_send_output=True,
     use_origin=True,
-    # WARNING: only one output_converter Extension may be attached to this
-    # matcher. Future special-output customisation must be merged INTO
-    # HelpImageExtension. See utils/help_extension.py docstring.
     extensions=[HelpImageExtension()],
 )
 

--- a/nonebot_plugin_tetris_stats/games/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/__init__.py
@@ -21,10 +21,6 @@ command: Alconna = Alconna(
     ),
     formatter_type=StructuredHelpFormatter,
 )
-# StructuredHelpFormatter needs the root reference to resolve canonical
-# subcommand metadata. Alconna instantiates formatter_type into self.formatter,
-# we just back-fill the root pointer here.
-command.formatter.root = command  # type: ignore[attr-defined]
 
 alc = on_alconna(
     command=command,

--- a/nonebot_plugin_tetris_stats/games/tetrio/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/__init__.py
@@ -1,18 +1,18 @@
 from nonebot_plugin_alconna import Subcommand
 
-from ...utils.exception import MessageFormatError
 from .. import alc
 from .. import command as main_command
 from .api import Player
 from .constant import USER_ID, USER_NAME
 
 
-def get_player(user_id_or_name: str) -> Player | MessageFormatError:
+def get_player(user_id_or_name: str) -> Player:
     if USER_ID.match(user_id_or_name):
         return Player(user_id=user_id_or_name, trust=True)
     if USER_NAME.match(user_id_or_name):
         return Player(user_name=user_id_or_name, trust=True)
-    return MessageFormatError('用户名/ID不合法')
+    msg = '用户名/ID不合法'
+    raise ValueError(msg)
 
 
 command = Subcommand(

--- a/nonebot_plugin_tetris_stats/games/tetrio/config.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/config.py
@@ -28,7 +28,7 @@ command.add(
         ),
         Option(
             '--default-compare',
-            Arg('compare', parse_duration, notice='对比时间距离'),
+            Arg('compare', parse_duration, notice='对比时间距离 (如 7d, 2w, 24h)'),
             alias=['-DC', 'DefaultCompare'],
             help_text='设置默认对比时间距离',
         ),

--- a/nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py
@@ -1,6 +1,7 @@
 from datetime import timedelta, timezone
 
-from arclet.alconna import Arg, ArgFlag
+from arclet.alconna import Arg, Field
+from arclet.alconna.args import Empty
 from nonebot import get_driver
 from nonebot.adapters import Event
 from nonebot.matcher import Matcher
@@ -16,7 +17,7 @@ from sqlalchemy import select
 from ....db import query_bind_info, resolve_compare_delta, trigger
 from ....i18n import Lang
 from ....utils.duration import parse_duration
-from ....utils.exception import FallbackError
+from ....utils.exception import FallbackError, MessageFormatError
 from ....utils.typedefs import Me
 from ... import add_block_handlers, alc
 from .. import command, get_player
@@ -27,6 +28,20 @@ from ..typedefs import Template
 from .v1 import make_query_image_v1
 from .v2 import make_query_image_v2
 
+
+def _strict_player(s: str) -> Player:
+    """Raising version of ``get_player`` so an unrecognised string lets
+    ``UnionPattern`` fall through to the next alternative (e.g. ``Me``).
+
+    plugin-alconna re-orders union members to put callable patterns before
+    ``Me``'s Literal pattern, so a non-raising callable would short-circuit
+    legitimate self-reference inputs like ``我``.
+    """
+    res = get_player(s)
+    if isinstance(res, MessageFormatError):
+        raise ValueError(str(res))  # noqa: TRY004
+    return res
+
 UTC = timezone.utc
 
 driver = get_driver()
@@ -36,16 +51,10 @@ command.add(
         'query',
         Args(
             Arg(
-                'target',
-                At | Me,
-                notice='@想要查询的人 / 自己',
-                flags=[ArgFlag.HIDDEN, ArgFlag.OPTIONAL],
-            ),
-            Arg(
-                'account',
-                get_player,
-                notice='TETR.IO 用户名 / ID',
-                flags=[ArgFlag.HIDDEN, ArgFlag.OPTIONAL],
+                'who',
+                At | Me | _strict_player,
+                notice='@想要查询的人 / 自己 / TETR.IO 用户名 / ID',
+                field=Field(default=Empty),
             ),
         ),
         Option(
@@ -96,7 +105,7 @@ async def _(  # noqa: PLR0913
     user: NBUser,
     event: Event,
     matcher: Matcher,
-    target: At | Me,
+    who: At | Me,
     event_session: Uninfo,
     template: Template | None = None,
     compare: timedelta | None = None,
@@ -116,7 +125,7 @@ async def _(  # noqa: PLR0913
             bind = await query_bind_info(
                 session=session,
                 user=await get_user(
-                    event_session.scope, target.target if isinstance(target, At) else event.get_user_id()
+                    event_session.scope, who.target if isinstance(who, At) else event.get_user_id()
                 ),
                 game_platform=GAME_TYPE,
             )
@@ -142,7 +151,7 @@ async def _(  # noqa: PLR0913
 @alc.assign('TETRIO.query')
 async def _(
     user: NBUser,
-    account: Player,
+    who: Player,
     event_session: Uninfo,
     template: Template | None = None,
     compare: timedelta | None = None,
@@ -164,4 +173,4 @@ async def _(
                     select(TETRIOUserConfig.query_template).where(TETRIOUserConfig.id == user.id)
                 )
             compare_delta = await resolve_compare_delta(TETRIOUserConfig, session, user.id, compare)
-        await (await make_query_result(account, template or 'v1', compare_delta)).finish()
+        await (await make_query_result(who, template or 'v1', compare_delta)).finish()

--- a/nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py
@@ -43,13 +43,13 @@ command.add(
         ),
         Option(
             '--template',
-            Arg('template', Template),
+            Arg('template', Template, notice='模板版本'),
             alias=['-T'],
             help_text='要使用的查询模板',
         ),
         Option(
             '--compare',
-            Arg('compare', parse_duration),
+            Arg('compare', parse_duration, notice='对比时间距离 (如 7d, 2w, 24h)'),
             alias=['-C'],
             help_text='指定对比时间距离',
         ),

--- a/nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py
@@ -17,7 +17,7 @@ from sqlalchemy import select
 from ....db import query_bind_info, resolve_compare_delta, trigger
 from ....i18n import Lang
 from ....utils.duration import parse_duration
-from ....utils.exception import FallbackError, MessageFormatError
+from ....utils.exception import FallbackError
 from ....utils.typedefs import Me
 from ... import add_block_handlers, alc
 from .. import command, get_player
@@ -27,20 +27,6 @@ from ..models import TETRIOUserConfig
 from ..typedefs import Template
 from .v1 import make_query_image_v1
 from .v2 import make_query_image_v2
-
-
-def _strict_player(s: str) -> Player:
-    """Raising version of ``get_player`` so an unrecognised string lets
-    ``UnionPattern`` fall through to the next alternative (e.g. ``Me``).
-
-    plugin-alconna re-orders union members to put callable patterns before
-    ``Me``'s Literal pattern, so a non-raising callable would short-circuit
-    legitimate self-reference inputs like ``我``.
-    """
-    res = get_player(s)
-    if isinstance(res, MessageFormatError):
-        raise ValueError(str(res))  # noqa: TRY004
-    return res
 
 UTC = timezone.utc
 
@@ -52,7 +38,7 @@ command.add(
         Args(
             Arg(
                 'who',
-                At | Me | _strict_player,
+                At | Me | get_player,
                 notice='@想要查询的人 / 自己 / TETR.IO 用户名 / ID',
                 field=Field(default=Empty),
             ),

--- a/nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py
@@ -1,7 +1,6 @@
 from datetime import timedelta, timezone
 
-from arclet.alconna import Arg, Field
-from arclet.alconna.args import Empty
+from arclet.alconna import Arg
 from nonebot import get_driver
 from nonebot.adapters import Event
 from nonebot.matcher import Matcher
@@ -40,7 +39,6 @@ command.add(
                 'who',
                 At | Me | get_player,
                 notice='@想要查询的人 / 自己 / TETR.IO 用户名 / ID',
-                field=Field(default=Empty),
             ),
         ),
         Option(

--- a/nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py
@@ -108,9 +108,7 @@ async def _(  # noqa: PLR0913
         async with get_session() as session:
             bind = await query_bind_info(
                 session=session,
-                user=await get_user(
-                    event_session.scope, who.target if isinstance(who, At) else event.get_user_id()
-                ),
+                user=await get_user(event_session.scope, who.target if isinstance(who, At) else event.get_user_id()),
                 game_platform=GAME_TYPE,
             )
             if template is None:

--- a/nonebot_plugin_tetris_stats/games/tetrio/rank/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/rank/__init__.py
@@ -44,15 +44,17 @@ command = Subcommand('rank', help_text='查询 TETR.IO 段位信息')
 
 
 def wrapper(slot: int | str, content: str | None) -> str | None:
-    if slot == 'rank' and not content:
-        return '--all'
-    if content is not None:
+    if slot == 'rank':
+        if not content:
+            return '--all'
+        if content.lower() in ('--help', '-h'):
+            return content
         return f'--detail {content.lower()}'
     return content
 
 
 alc.shortcut(
-    r'(?i:io)(?i:段位|段|rank)\s*(?P<rank>[a-zA-Z+-]{0,2})',
+    r'(?i:io)(?i:段位|段|rank)\s*(?P<rank>[a-zA-Z][a-zA-Z+-]?|--help|-h)?',
     command='tstats TETR.IO rank {rank}',
     humanized='iorank',
     fuzzy=False,

--- a/nonebot_plugin_tetris_stats/games/tetrio/rank/all.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/rank/all.py
@@ -25,7 +25,8 @@ from . import command
 
 command.add(
     Subcommand(
-        '--all', Option('--template', Arg('template', Template, notice='模板版本'), alias=['-T'], help_text='要使用的查询模板'),
+        '--all',
+        Option('--template', Arg('template', Template, notice='模板版本'), alias=['-T'], help_text='要使用的查询模板'),
         dest='all',
         help_text='查询所有段位概览',
     )

--- a/nonebot_plugin_tetris_stats/games/tetrio/rank/all.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/rank/all.py
@@ -25,7 +25,9 @@ from . import command
 
 command.add(
     Subcommand(
-        '--all', Option('--template', Arg('template', Template), alias=['-T'], help_text='要使用的查询模板'), dest='all'
+        '--all', Option('--template', Arg('template', Template), alias=['-T'], help_text='要使用的查询模板'),
+        dest='all',
+        help_text='查询所有段位概览',
     )
 )
 

--- a/nonebot_plugin_tetris_stats/games/tetrio/rank/all.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/rank/all.py
@@ -25,7 +25,7 @@ from . import command
 
 command.add(
     Subcommand(
-        '--all', Option('--template', Arg('template', Template), alias=['-T'], help_text='要使用的查询模板'),
+        '--all', Option('--template', Arg('template', Template, notice='模板版本'), alias=['-T'], help_text='要使用的查询模板'),
         dest='all',
         help_text='查询所有段位概览',
     )

--- a/nonebot_plugin_tetris_stats/games/tetrio/rank/detail.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/rank/detail.py
@@ -25,7 +25,7 @@ UTC = timezone.utc
 
 driver = get_driver()
 
-command.add(Subcommand('--detail', Arg('rank', ValidRank), alias=['-D'], dest='detail', help_text='查询指定段位的详细信息'))
+command.add(Subcommand('--detail', Arg('rank', ValidRank, notice='段位名 (如 s+, x, b-)'), alias=['-D'], dest='detail', help_text='查询指定段位的详细信息'))
 
 
 @alc.assign('TETRIO.rank.detail')

--- a/nonebot_plugin_tetris_stats/games/tetrio/rank/detail.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/rank/detail.py
@@ -3,7 +3,7 @@ from zoneinfo import ZoneInfo
 
 from arclet.alconna import Arg
 from nonebot import get_driver
-from nonebot_plugin_alconna import Option, UniMessage
+from nonebot_plugin_alconna import Subcommand, UniMessage
 from nonebot_plugin_orm import get_session
 from nonebot_plugin_uninfo import Uninfo
 from nonebot_plugin_uninfo.orm import get_session_persist_id
@@ -25,10 +25,10 @@ UTC = timezone.utc
 
 driver = get_driver()
 
-command.add(Option('--detail', Arg('rank', ValidRank), alias=['-D']))
+command.add(Subcommand('--detail', Arg('rank', ValidRank), alias=['-D'], dest='detail', help_text='查询指定段位的详细信息'))
 
 
-@alc.assign('TETRIO.rank')
+@alc.assign('TETRIO.rank.detail')
 async def _(rank: ValidRank, event_session: Uninfo):
     async with trigger(
         session_persist_id=await get_session_persist_id(event_session),

--- a/nonebot_plugin_tetris_stats/games/tetrio/rank/detail.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/rank/detail.py
@@ -25,7 +25,15 @@ UTC = timezone.utc
 
 driver = get_driver()
 
-command.add(Subcommand('--detail', Arg('rank', ValidRank, notice='段位名 (如 s+, x, b-)'), alias=['-D'], dest='detail', help_text='查询指定段位的详细信息'))
+command.add(
+    Subcommand(
+        '--detail',
+        Arg('rank', ValidRank, notice='段位名 (如 s+, x, b-)'),
+        alias=['-D'],
+        dest='detail',
+        help_text='查询指定段位的详细信息',
+    )
+)
 
 
 @alc.assign('TETRIO.rank.detail')

--- a/nonebot_plugin_tetris_stats/games/tetrio/rank/detail.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/rank/detail.py
@@ -28,7 +28,7 @@ driver = get_driver()
 command.add(
     Subcommand(
         '--detail',
-        Arg('rank', ValidRank, notice='段位名 (如 s+, x, b-)'),
+        Arg('rank', ValidRank, notice='段位名'),
         alias=['-D'],
         dest='detail',
         help_text='查询指定段位的详细信息',

--- a/nonebot_plugin_tetris_stats/games/tetrio/record/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/record/__init__.py
@@ -1,5 +1,4 @@
-from arclet.alconna import Arg, Field
-from arclet.alconna.args import Empty
+from arclet.alconna import Arg
 from nonebot_plugin_alconna import Args, At, Subcommand
 
 from ....utils.typedefs import Me
@@ -13,7 +12,6 @@ command = Subcommand(
             'who',
             At | Me | get_player,
             notice='@想要查询的人 / 自己 / TETR.IO 用户名 / ID',
-            field=Field(default=Empty),
         ),
     ),
 )

--- a/nonebot_plugin_tetris_stats/games/tetrio/record/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/record/__init__.py
@@ -1,4 +1,5 @@
-from arclet.alconna import Arg, ArgFlag
+from arclet.alconna import Arg, Field
+from arclet.alconna.args import Empty
 from nonebot_plugin_alconna import Args, At, Subcommand
 
 from ....utils.typedefs import Me
@@ -9,16 +10,10 @@ command = Subcommand(
     'record',
     Args(
         Arg(
-            'target',
-            At | Me,
-            notice='@想要查询的人 / 自己',
-            flags=[ArgFlag.HIDDEN, ArgFlag.OPTIONAL],
-        ),
-        Arg(
-            'account',
-            get_player,
-            notice='TETR.IO 用户名 / ID',
-            flags=[ArgFlag.HIDDEN, ArgFlag.OPTIONAL],
+            'who',
+            At | Me | get_player,
+            notice='@想要查询的人 / 自己 / TETR.IO 用户名 / ID',
+            field=Field(default=Empty),
         ),
     ),
 )

--- a/nonebot_plugin_tetris_stats/games/tetrio/record/blitz.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/record/blitz.py
@@ -53,9 +53,7 @@ async def _(
         async with get_session() as session:
             bind = await query_bind_info(
                 session=session,
-                user=await get_user(
-                    event_session.scope, who.target if isinstance(who, At) else event.get_user_id()
-                ),
+                user=await get_user(event_session.scope, who.target if isinstance(who, At) else event.get_user_id()),
                 game_platform=GAME_TYPE,
             )
         if bind is None:

--- a/nonebot_plugin_tetris_stats/games/tetrio/record/blitz.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/record/blitz.py
@@ -41,7 +41,7 @@ alc.shortcut(
 async def _(
     event: Event,
     matcher: Matcher,
-    target: At | Me,
+    who: At | Me,
     event_session: Uninfo,
 ):
     async with trigger(
@@ -54,7 +54,7 @@ async def _(
             bind = await query_bind_info(
                 session=session,
                 user=await get_user(
-                    event_session.scope, target.target if isinstance(target, At) else event.get_user_id()
+                    event_session.scope, who.target if isinstance(who, At) else event.get_user_id()
                 ),
                 game_platform=GAME_TYPE,
             )
@@ -67,14 +67,14 @@ async def _(
 
 
 @alc.assign('TETRIO.record.blitz')
-async def _(account: Player, event_session: Uninfo):
+async def _(who: Player, event_session: Uninfo):
     async with trigger(
         session_persist_id=await get_session_persist_id(event_session),
         game_platform=GAME_TYPE,
         command_type='record',
         command_args=['--blitz'],
     ):
-        await UniMessage.image(raw=await make_blitz_image(account)).finish()
+        await UniMessage.image(raw=await make_blitz_image(who)).finish()
 
 
 async def make_blitz_image(player: Player) -> bytes:

--- a/nonebot_plugin_tetris_stats/games/tetrio/record/sprint.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/record/sprint.py
@@ -53,9 +53,7 @@ async def _(
         async with get_session() as session:
             bind = await query_bind_info(
                 session=session,
-                user=await get_user(
-                    event_session.scope, who.target if isinstance(who, At) else event.get_user_id()
-                ),
+                user=await get_user(event_session.scope, who.target if isinstance(who, At) else event.get_user_id()),
                 game_platform=GAME_TYPE,
             )
         if bind is None:

--- a/nonebot_plugin_tetris_stats/games/tetrio/record/sprint.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/record/sprint.py
@@ -41,7 +41,7 @@ alc.shortcut(
 async def _(
     event: Event,
     matcher: Matcher,
-    target: At | Me,
+    who: At | Me,
     event_session: Uninfo,
 ):
     async with trigger(
@@ -54,7 +54,7 @@ async def _(
             bind = await query_bind_info(
                 session=session,
                 user=await get_user(
-                    event_session.scope, target.target if isinstance(target, At) else event.get_user_id()
+                    event_session.scope, who.target if isinstance(who, At) else event.get_user_id()
                 ),
                 game_platform=GAME_TYPE,
             )
@@ -67,14 +67,14 @@ async def _(
 
 
 @alc.assign('TETRIO.record.sprint')
-async def _(account: Player, event_session: Uninfo):
+async def _(who: Player, event_session: Uninfo):
     async with trigger(
         session_persist_id=await get_session_persist_id(event_session),
         game_platform=GAME_TYPE,
         command_type='record',
         command_args=['--40l'],
     ):
-        await UniMessage.image(raw=await make_sprint_image(account)).finish()
+        await UniMessage.image(raw=await make_sprint_image(who)).finish()
 
 
 async def make_sprint_image(player: Player) -> bytes:

--- a/nonebot_plugin_tetris_stats/games/top/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/top/__init__.py
@@ -1,5 +1,4 @@
-from arclet.alconna import Arg, ArgFlag, Field
-from arclet.alconna.args import Empty
+from arclet.alconna import Arg, ArgFlag
 from nonebot_plugin_alconna import Args, At, Option, Subcommand
 
 from ...utils.duration import parse_duration
@@ -52,7 +51,6 @@ command.add(
                     'who',
                     At | Me | get_player,
                     notice='@想要查询的人 / 自己 / TOP 用户名',
-                    field=Field(default=Empty),
                 ),
             ),
             Option(

--- a/nonebot_plugin_tetris_stats/games/top/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/top/__init__.py
@@ -38,7 +38,7 @@ command.add(
             'config',
             Option(
                 '--default-compare',
-                Arg('compare', parse_duration, notice='对比时间距离'),
+                Arg('compare', parse_duration, notice='对比时间距离 (如 7d, 2w, 24h)'),
                 alias=['-DC', 'DefaultCompare'],
                 help_text='设置默认对比时间距离',
             ),
@@ -55,7 +55,7 @@ command.add(
             ),
             Option(
                 '--compare',
-                Arg('compare', parse_duration),
+                Arg('compare', parse_duration, notice='对比时间距离 (如 7d, 2w, 24h)'),
                 alias=['-C'],
                 help_text='指定对比时间距离',
             ),

--- a/nonebot_plugin_tetris_stats/games/top/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/top/__init__.py
@@ -1,4 +1,5 @@
-from arclet.alconna import Arg, ArgFlag
+from arclet.alconna import Arg, ArgFlag, Field
+from arclet.alconna.args import Empty
 from nonebot_plugin_alconna import Args, At, Option, Subcommand
 
 from ...utils.duration import parse_duration
@@ -48,16 +49,10 @@ command.add(
             'query',
             Args(
                 Arg(
-                    'target',
-                    At | Me,
-                    notice='@想要查询的人 / 自己',
-                    flags=[ArgFlag.HIDDEN, ArgFlag.OPTIONAL],
-                ),
-                Arg(
-                    'account',
-                    get_player,
-                    notice='TOP 用户名',
-                    flags=[ArgFlag.HIDDEN, ArgFlag.OPTIONAL],
+                    'who',
+                    At | Me | get_player,
+                    notice='@想要查询的人 / 自己 / TOP 用户名',
+                    field=Field(default=Empty),
                 ),
             ),
             Option(

--- a/nonebot_plugin_tetris_stats/games/top/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/top/__init__.py
@@ -2,17 +2,17 @@ from arclet.alconna import Arg, ArgFlag
 from nonebot_plugin_alconna import Args, At, Option, Subcommand
 
 from ...utils.duration import parse_duration
-from ...utils.exception import MessageFormatError
 from ...utils.typedefs import Me
 from .. import add_block_handlers, alc, command
 from .api import Player
 from .constant import USER_NAME
 
 
-def get_player(name: str) -> Player | MessageFormatError:
+def get_player(name: str) -> Player:
     if USER_NAME.match(name):
         return Player(user_name=name, trust=True)
-    return MessageFormatError('用户名/ID不合法')
+    msg = '用户名/ID不合法'
+    raise ValueError(msg)
 
 
 command.add(

--- a/nonebot_plugin_tetris_stats/games/top/query.py
+++ b/nonebot_plugin_tetris_stats/games/top/query.py
@@ -97,9 +97,7 @@ async def _(  # noqa: PLR0913
         async with get_session() as session:
             bind = await query_bind_info(
                 session=session,
-                user=await get_user(
-                    event_session.scope, who.target if isinstance(who, At) else event.get_user_id()
-                ),
+                user=await get_user(event_session.scope, who.target if isinstance(who, At) else event.get_user_id()),
                 game_platform=GAME_TYPE,
             )
             if bind is None:

--- a/nonebot_plugin_tetris_stats/games/top/query.py
+++ b/nonebot_plugin_tetris_stats/games/top/query.py
@@ -84,7 +84,7 @@ async def _(  # noqa: PLR0913
     user: NBUser,
     event: Event,
     matcher: Matcher,
-    target: At | Me,
+    who: At | Me,
     event_session: Uninfo,
     compare: timedelta | None = None,
 ):
@@ -98,7 +98,7 @@ async def _(  # noqa: PLR0913
             bind = await query_bind_info(
                 session=session,
                 user=await get_user(
-                    event_session.scope, target.target if isinstance(target, At) else event.get_user_id()
+                    event_session.scope, who.target if isinstance(who, At) else event.get_user_id()
                 ),
                 game_platform=GAME_TYPE,
             )
@@ -124,7 +124,7 @@ async def _(  # noqa: PLR0913
 
 
 @alc.assign('TOP.query')
-async def _(user: NBUser, account: Player, event_session: Uninfo, compare: timedelta | None = None):
+async def _(user: NBUser, who: Player, event_session: Uninfo, compare: timedelta | None = None):
     async with trigger(
         session_persist_id=await get_session_persist_id(event_session),
         game_platform=GAME_TYPE,
@@ -133,7 +133,7 @@ async def _(user: NBUser, account: Player, event_session: Uninfo, compare: timed
     ):
         async with get_session() as session:
             compare_delta = await resolve_compare_delta(TOPUserConfig, session, user.id, compare)
-            profile = await account.get_profile()
+            profile = await who.get_profile()
             compare_profile = await get_compare_profile(
                 session,
                 profile.user_name,

--- a/nonebot_plugin_tetris_stats/games/tos/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tos/__init__.py
@@ -43,7 +43,7 @@ command.add(
             'config',
             Option(
                 '--default-compare',
-                Arg('compare', parse_duration, notice='对比时间距离'),
+                Arg('compare', parse_duration, notice='对比时间距离 (如 7d, 2w, 24h)'),
                 alias=['-DC', 'DefaultCompare'],
                 help_text='设置默认对比时间距离',
             ),
@@ -60,7 +60,7 @@ command.add(
             ),
             Option(
                 '--compare',
-                Arg('compare', parse_duration),
+                Arg('compare', parse_duration, notice='对比时间距离 (如 7d, 2w, 24h)'),
                 alias=['-C'],
                 help_text='指定对比时间距离',
             ),

--- a/nonebot_plugin_tetris_stats/games/tos/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tos/__init__.py
@@ -1,5 +1,4 @@
-from arclet.alconna import Arg, ArgFlag, Field
-from arclet.alconna.args import Empty
+from arclet.alconna import Arg, ArgFlag
 from nonebot_plugin_alconna import Args, At, Option, Subcommand
 
 from ...utils.duration import parse_duration
@@ -57,7 +56,6 @@ command.add(
                     'who',
                     At | Me | get_player,
                     notice='@想要查询的人 / 自己 / 茶服 用户名 / TeaID',
-                    field=Field(default=Empty),
                 ),
             ),
             Option(

--- a/nonebot_plugin_tetris_stats/games/tos/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tos/__init__.py
@@ -2,14 +2,13 @@ from arclet.alconna import Arg, ArgFlag
 from nonebot_plugin_alconna import Args, At, Option, Subcommand
 
 from ...utils.duration import parse_duration
-from ...utils.exception import MessageFormatError
 from ...utils.typedefs import Me
 from .. import add_block_handlers, alc, command
 from .api import Player
 from .constant import USER_NAME
 
 
-def get_player(teaid_or_name: str) -> Player | MessageFormatError:
+def get_player(teaid_or_name: str) -> Player:
     if (
         teaid_or_name.startswith(('onebot-', 'qqguild-', 'kook-', 'discord-'))
         and teaid_or_name.split('-', maxsplit=1)[1].isdigit()
@@ -17,7 +16,8 @@ def get_player(teaid_or_name: str) -> Player | MessageFormatError:
         return Player(teaid=teaid_or_name, trust=True)
     if USER_NAME.match(teaid_or_name) and not teaid_or_name.isdigit() and 2 <= len(teaid_or_name) <= 18:  # noqa: PLR2004
         return Player(user_name=teaid_or_name, trust=True)
-    return MessageFormatError('用户名/ID不合法')
+    msg = '用户名/ID不合法'
+    raise ValueError(msg)
 
 
 command.add(

--- a/nonebot_plugin_tetris_stats/games/tos/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tos/__init__.py
@@ -1,4 +1,5 @@
-from arclet.alconna import Arg, ArgFlag
+from arclet.alconna import Arg, ArgFlag, Field
+from arclet.alconna.args import Empty
 from nonebot_plugin_alconna import Args, At, Option, Subcommand
 
 from ...utils.duration import parse_duration
@@ -53,16 +54,10 @@ command.add(
             'query',
             Args(
                 Arg(
-                    'target',
-                    At | Me,
-                    notice='@想要查询的人 / 自己',
-                    flags=[ArgFlag.HIDDEN, ArgFlag.OPTIONAL],
-                ),
-                Arg(
-                    'account',
-                    get_player,
-                    notice='茶服 用户名 / TeaID',
-                    flags=[ArgFlag.HIDDEN, ArgFlag.OPTIONAL],
+                    'who',
+                    At | Me | get_player,
+                    notice='@想要查询的人 / 自己 / 茶服 用户名 / TeaID',
+                    field=Field(default=Empty),
                 ),
             ),
             Option(

--- a/nonebot_plugin_tetris_stats/games/tos/query.py
+++ b/nonebot_plugin_tetris_stats/games/tos/query.py
@@ -50,7 +50,7 @@ def add_special_handlers(
     async def _(
         user: NBUser,
         event: Event,
-        target: At | Me,
+        who: At | Me,
         event_session: Uninfo,
         compare: timedelta | None = None,
     ):
@@ -62,8 +62,8 @@ def add_special_handlers(
                 command_args=[f'--compare {compare}'] if compare is not None else [],
             ):
                 player = Player(
-                    teaid=f'{teaid_prefix}{target.target}'
-                    if isinstance(target, At)
+                    teaid=f'{teaid_prefix}{who.target}'
+                    if isinstance(who, At)
                     else f'{teaid_prefix}{event.get_user_id()}',
                     trust=True,
                 )
@@ -73,7 +73,7 @@ def add_special_handlers(
                             await make_query_result(
                                 player,
                                 await resolve_compare_delta(TOSUserConfig, session, user.id, compare),
-                                None if isinstance(target, At) else event_session.user,
+                                None if isinstance(who, At) else event_session.user,
                             )
                         ).finish()
                 except RequestError as e:
@@ -125,7 +125,7 @@ async def _(  # noqa: PLR0913
     user: NBUser,
     event: Event,
     matcher: Matcher,
-    target: At | Me,
+    who: At | Me,
     event_session: Uninfo,
     compare: timedelta | None = None,
 ):
@@ -140,7 +140,7 @@ async def _(  # noqa: PLR0913
     ):
         bind = await query_bind_info(
             session=session,
-            user=await get_user(event_session.scope, target.target if isinstance(target, At) else event.get_user_id()),
+            user=await get_user(event_session.scope, who.target if isinstance(who, At) else event.get_user_id()),
             game_platform=GAME_TYPE,
         )
         if bind is None:
@@ -154,7 +154,7 @@ async def _(  # noqa: PLR0913
                     result := await make_query_result(
                         player,
                         await resolve_compare_delta(TOSUserConfig, session, user.id, compare),
-                        None if isinstance(target, At) else event_session.user,
+                        None if isinstance(who, At) else event_session.user,
                     )
                 ).has(Image)
                 else UniMessage()
@@ -164,7 +164,7 @@ async def _(  # noqa: PLR0913
 
 
 @alc.assign('TOS.query')
-async def _(user: NBUser, account: Player, event_session: Uninfo, compare: timedelta | None = None):
+async def _(user: NBUser, who: Player, event_session: Uninfo, compare: timedelta | None = None):
     async with (
         trigger(
             session_persist_id=await get_session_persist_id(event_session),
@@ -176,7 +176,7 @@ async def _(user: NBUser, account: Player, event_session: Uninfo, compare: timed
     ):
         await (
             await make_query_result(
-                account,
+                who,
                 await resolve_compare_delta(TOSUserConfig, session, user.id, compare),
                 None,
             )

--- a/nonebot_plugin_tetris_stats/utils/help_extension.py
+++ b/nonebot_plugin_tetris_stats/utils/help_extension.py
@@ -1,0 +1,54 @@
+"""Extension that converts structured help JSON into an image message.
+
+WARNING - exclusive semantics: ``SelectedExtensions.output_converter()`` uses a
+"first override returns" semantic (see nonebot_plugin_alconna/extension.py:248-259),
+NOT a chain. Only ONE output_converter Extension may be attached to a given
+matcher. Future error / shortcut / completion output customisation MUST be
+merged into this Extension - do NOT stack additional ones.
+
+WARNING - depends on ``on_alconna(auto_send_output=True)``: image messages
+flow through the nbp-alc auto-send path (rule.py:353-375). If this option is
+ever turned off, help images will silently stop being sent.
+"""
+
+from nonebot_plugin_alconna import Extension, UniMessage
+from nonebot_plugin_alconna.extension import OutputType
+from typing_extensions import override
+
+from .help_formatter import HELP_JSON_PREFIX
+
+
+class HelpImageExtension(Extension):
+    @property
+    @override
+    def priority(self) -> int:
+        return 10
+
+    @property
+    @override
+    def id(self) -> str:
+        return 'tetris-stats:help-image'
+
+    @override
+    async def output_converter(self, output_type: OutputType, content: str) -> UniMessage:
+        # Non-help types or content that is not our private envelope: return
+        # an empty UniMessage so nbp-alc rule.py:372 (`if not msg`) falls back
+        # to the original text. This keeps shortcut / completion / error
+        # outputs working unchanged.
+        if output_type != 'help' or not content.startswith(HELP_JSON_PREFIX):
+            return UniMessage()
+        # Lazy import avoids circular dependency with games/* during plugin load
+        # (render/__init__.py -> host.py -> games.tetrio.api.cache).
+        from .render import render_image  # noqa: PLC0415
+        from .render.schemas.help import HelpData  # noqa: PLC0415
+
+        try:
+            data = HelpData.model_validate_json(content[len(HELP_JSON_PREFIX) :])
+            img = await render_image(data)
+        except Exception as e:
+            # Extension/render-stage exceptions do NOT land in arp.error_info;
+            # they bubble out of send(). Wrap in a semantic exception so logs
+            # show the high-level cause clearly.
+            msg = 'failed to render structured help image'
+            raise RuntimeError(msg) from e
+        return UniMessage.image(raw=img)

--- a/nonebot_plugin_tetris_stats/utils/help_extension.py
+++ b/nonebot_plugin_tetris_stats/utils/help_extension.py
@@ -20,8 +20,6 @@ from nonebot_plugin_alconna import Extension, UniMessage
 from nonebot_plugin_alconna.extension import OutputType
 from typing_extensions import override
 
-from .help_formatter import HELP_JSON_PREFIX
-
 # Built-in option names that trigger help. Mirrors Alconna's default
 # namespace.builtin_option_name['help'] (-h / --help). We rewrite alias
 # subcommand tokens only when one of these is present, to avoid touching
@@ -94,11 +92,10 @@ class HelpImageExtension(Extension):
 
     @override
     async def output_converter(self, output_type: OutputType, content: str) -> UniMessage:
-        # Non-help types or content that is not our private envelope: return
-        # an empty UniMessage so nbp-alc rule.py:372 (`if not msg`) falls back
-        # to the original text. This keeps shortcut / completion / error
-        # outputs working unchanged.
-        if output_type != 'help' or not content.startswith(HELP_JSON_PREFIX):
+        # Non-help types: return an empty UniMessage so nbp-alc rule.py:372
+        # (`if not msg`) falls back to the original text. This keeps shortcut /
+        # completion / error outputs working unchanged.
+        if output_type != 'help':
             return UniMessage()
         # Lazy import avoids circular dependency with games/* during plugin load
         # (render/__init__.py -> host.py -> games.tetrio.api.cache).
@@ -106,7 +103,7 @@ class HelpImageExtension(Extension):
         from .render.schemas.help import HelpData  # noqa: PLC0415
 
         try:
-            data = type_validate_json(HelpData, content[len(HELP_JSON_PREFIX) :])
+            data = type_validate_json(HelpData, content)
             img = await render_image(data)
         except Exception as e:
             # Extension/render-stage exceptions do NOT land in arp.error_info;

--- a/nonebot_plugin_tetris_stats/utils/help_extension.py
+++ b/nonebot_plugin_tetris_stats/utils/help_extension.py
@@ -15,6 +15,7 @@ ever turned off, help images will silently stop being sent.
 
 from arclet.alconna import Alconna, Subcommand
 from nonebot.adapters import Bot, Event
+from nonebot.compat import type_validate_json
 from nonebot_plugin_alconna import Extension, UniMessage
 from nonebot_plugin_alconna.extension import OutputType
 from typing_extensions import override
@@ -105,7 +106,7 @@ class HelpImageExtension(Extension):
         from .render.schemas.help import HelpData  # noqa: PLC0415
 
         try:
-            data = HelpData.model_validate_json(content[len(HELP_JSON_PREFIX) :])
+            data = type_validate_json(HelpData, content[len(HELP_JSON_PREFIX) :])
             img = await render_image(data)
         except Exception as e:
             # Extension/render-stage exceptions do NOT land in arp.error_info;

--- a/nonebot_plugin_tetris_stats/utils/help_extension.py
+++ b/nonebot_plugin_tetris_stats/utils/help_extension.py
@@ -1,4 +1,6 @@
-"""Extension that converts structured help JSON into an image message.
+"""Extension that converts structured help JSON into an image message,
+and rewrites alias subcommand tokens before --help so Alconna can route the
+help request to the correct subcommand.
 
 WARNING - exclusive semantics: ``SelectedExtensions.output_converter()`` uses a
 "first override returns" semantic (see nonebot_plugin_alconna/extension.py:248-259),
@@ -11,11 +13,36 @@ flow through the nbp-alc auto-send path (rule.py:353-375). If this option is
 ever turned off, help images will silently stop being sent.
 """
 
+from arclet.alconna import Alconna, Subcommand
+from nonebot.adapters import Bot, Event
 from nonebot_plugin_alconna import Extension, UniMessage
 from nonebot_plugin_alconna.extension import OutputType
 from typing_extensions import override
 
 from .help_formatter import HELP_JSON_PREFIX
+
+# Built-in option names that trigger help. Mirrors Alconna's default
+# namespace.builtin_option_name['help'] (-h / --help). We rewrite alias
+# subcommand tokens only when one of these is present, to avoid touching
+# regular command parsing.
+_HELP_TOKENS = frozenset({'--help', '-h'})
+
+
+def _build_alias_index(root: Alconna) -> dict[str, str]:
+    """Map every casefolded alias / dest -> canonical Subcommand.name.
+
+    Only top-level subcommands need rewriting; deeper levels parse normally
+    once the first alias token is promoted to its canonical name.
+    """
+    index: dict[str, str] = {}
+    for child in root.options:
+        if not isinstance(child, Subcommand):
+            continue
+        canonical = child.name
+        for token in {child.name, child.dest, *child.aliases}:
+            cf = token.casefold()
+            index.setdefault(cf, canonical)
+    return index
 
 
 class HelpImageExtension(Extension):
@@ -28,6 +55,41 @@ class HelpImageExtension(Extension):
     @override
     def id(self) -> str:
         return 'tetris-stats:help-image'
+
+    @override
+    async def receive_wrapper(
+        self,
+        bot: Bot,
+        event: Event,
+        command: Alconna,
+        receive: UniMessage,
+    ) -> UniMessage:
+        # Only rewrite when --help / -h is present; otherwise leave parsing alone.
+        text = receive.extract_plain_text()
+        tokens = text.split()
+        if not tokens or not _HELP_TOKENS.intersection(tokens):
+            return receive
+
+        alias_index = _build_alias_index(command)
+        if not alias_index:
+            return receive
+
+        # Find the first token (after the root command name) that is an alias
+        # and promote it to the canonical Subcommand.name. Stop at --help/-h.
+        rewritten: list[str] | None = None
+        for i, tok in enumerate(tokens[1:], start=1):
+            if tok in _HELP_TOKENS:
+                break
+            canonical = alias_index.get(tok.casefold())
+            if canonical is None or canonical == tok:
+                continue
+            rewritten = [*tokens[:i], canonical, *tokens[i + 1 :]]
+            break
+
+        if rewritten is None:
+            return receive
+
+        return UniMessage(' '.join(rewritten))
 
     @override
     async def output_converter(self, output_type: OutputType, content: str) -> UniMessage:

--- a/nonebot_plugin_tetris_stats/utils/help_formatter.py
+++ b/nonebot_plugin_tetris_stats/utils/help_formatter.py
@@ -163,11 +163,7 @@ def _collect_shortcuts(root: Alconna) -> list[tuple[str, list[str]]]:
             results.append((key, [root.header_display]))
             continue
         cmd_text = _extract_command_text(short.command)
-        target = (
-            [tok for tok in cmd_text.split() if _is_path_segment(tok)]
-            if cmd_text
-            else [root.header_display]
-        )
+        target = [tok for tok in cmd_text.split() if _is_path_segment(tok)] if cmd_text else [root.header_display]
         suffix = _render_target_signature(root, target)
         rendered = f'{key} {suffix}' if suffix else key
         results.append((rendered, target))
@@ -287,7 +283,9 @@ class StructuredHelpFormatter(TextFormatter):
         else:
             usage = None
             examples = []
-            shortcuts = [HelpShortcut(key=k, target=t) for k, t in all_shortcuts if t[1:len(breadcrumb)] == breadcrumb[1:]]
+            shortcuts = [
+                HelpShortcut(key=k, target=t) for k, t in all_shortcuts if t[1 : len(breadcrumb)] == breadcrumb[1:]
+            ]
         data = HelpData(
             lang=get_lang(),
             command=node,

--- a/nonebot_plugin_tetris_stats/utils/help_formatter.py
+++ b/nonebot_plugin_tetris_stats/utils/help_formatter.py
@@ -112,10 +112,53 @@ def _is_path_segment(token: str) -> bool:
     return not token.startswith(('-', '{'))
 
 
+def _render_arg_token(name: str, *, optional: bool) -> str:
+    return f'[{name}]' if optional else f'<{name}>'
+
+
+def _render_target_signature(root: Alconna, target: list[str]) -> str:
+    """Render the args/options accepted by ``target`` as a usage-style suffix.
+
+    e.g. for shortcut ``io查`` whose target is ``tstats TETR.IO query``, this
+    returns ``[--template <template>] [--compare <compare>]``. Hidden args and
+    builtin options (--help / --shortcut / --comp) are skipped.
+    """
+    sub_path = target[1:]
+    if not sub_path:
+        args_iter = list(root.args.argument)
+        children = list(root.options)
+    else:
+        chain = _resolve_current_subcommand(root, sub_path)
+        if chain is None:
+            return ''
+        sub = chain[-1]
+        args_iter = list(sub.args.argument)
+        children = list(sub.options)
+
+    tokens: list[str] = []
+    for a in args_iter:
+        if a.hidden:
+            continue
+        tokens.append(_render_arg_token(a.name, optional=a.optional))
+    for child in children:
+        if isinstance(child, _BUILTINS) or not isinstance(child, Option):
+            continue
+        inner = [child.name]
+        for a in child.args.argument:
+            if a.hidden:
+                continue
+            inner.append(_render_arg_token(a.name, optional=a.optional))
+        tokens.append(f'[{" ".join(inner)}]')
+    return ' '.join(tokens)
+
+
 def _collect_shortcuts(root: Alconna) -> list[tuple[str, list[str]]]:
     """Return list of (humanized_key, target_path) pairs, filtering easter eggs.
 
     target_path is the full canonical breadcrumb starting with the root header.
+    The humanized key is suffixed with the target command's argument signature
+    (rendered in CLI ``<required>`` / ``[optional]`` syntax) so users can see
+    what they may / must supply, instead of the opaque ``...args`` placeholder.
     """
     results: list[tuple[str, list[str]]] = []
     for key, short in command_manager.get_shortcut(root).items():
@@ -125,12 +168,14 @@ def _collect_shortcuts(root: Alconna) -> list[tuple[str, list[str]]]:
             # Custom shortcut wrappers: cannot statically resolve target.
             results.append((key, [root.header_display]))
             continue
-        rendered = key + (' ...args' if short.fuzzy else '')
         cmd_text = _extract_command_text(short.command)
-        if cmd_text:
-            target = [tok for tok in cmd_text.split() if _is_path_segment(tok)]
-        else:
-            target = [root.header_display]
+        target = (
+            [tok for tok in cmd_text.split() if _is_path_segment(tok)]
+            if cmd_text
+            else [root.header_display]
+        )
+        suffix = _render_target_signature(root, target)
+        rendered = f'{key} {suffix}' if suffix else key
         results.append((rendered, target))
     return results
 

--- a/nonebot_plugin_tetris_stats/utils/help_formatter.py
+++ b/nonebot_plugin_tetris_stats/utils/help_formatter.py
@@ -20,7 +20,7 @@ from arclet.alconna.args import Arg
 from arclet.alconna.base import Completion, Help, Shortcut
 from arclet.alconna.formatter import TextFormatter, Trace
 from arclet.alconna.manager import InnerShortcutArgs, command_manager
-from typing_extensions import override
+from typing_extensions import Self, override
 
 if TYPE_CHECKING:
     from .render.schemas.help import HelpArg, HelpNode, HelpOption
@@ -210,15 +210,14 @@ def _resolve_current_subcommand(root: Alconna, sub_path: list[str]) -> list[Subc
 
 
 class StructuredHelpFormatter(TextFormatter):
-    """Returns a HelpData JSON string instead of plain text help.
-
-    Caller MUST back-fill ``root`` after Alconna instantiation::
-
-        command = Alconna(..., formatter_type=StructuredHelpFormatter)
-        command.formatter.root = command  # type: ignore[attr-defined]
-    """
+    """Returns a HelpData JSON string instead of plain text help."""
 
     root: Alconna | None = None
+
+    @override
+    def add(self, base: Alconna) -> Self:
+        self.root = base
+        return super().add(base)
 
     @override
     def format(self, trace: Trace) -> str:

--- a/nonebot_plugin_tetris_stats/utils/help_formatter.py
+++ b/nonebot_plugin_tetris_stats/utils/help_formatter.py
@@ -19,6 +19,7 @@ from arclet.alconna import Alconna, Option, Subcommand
 from arclet.alconna.args import Arg
 from arclet.alconna.base import Completion, Help, Shortcut
 from arclet.alconna.formatter import TextFormatter, Trace
+from arclet.alconna.manager import InnerShortcutArgs, command_manager
 from typing_extensions import override
 
 if TYPE_CHECKING:
@@ -81,6 +82,30 @@ def _sub_to_help(sub: Subcommand) -> 'HelpNode':
     )
 
 
+def _is_easter_egg(key: str) -> bool:
+    """Hidden shortcuts use 'easter egg' marker in their humanized key."""
+    return 'easter egg' in key.casefold()
+
+
+def _collect_shortcuts(root: Alconna) -> list[tuple[str, list[str]]]:
+    """Return list of (humanized_key, target_path) pairs, filtering easter eggs.
+
+    target_path is the full canonical breadcrumb starting with the root header.
+    """
+    results: list[tuple[str, list[str]]] = []
+    for key, short in command_manager.get_shortcut(root).items():
+        if _is_easter_egg(key):
+            continue
+        if not isinstance(short, InnerShortcutArgs):
+            # Custom shortcut wrappers: cannot statically resolve target.
+            results.append((key, [root.header_display]))
+            continue
+        rendered = key + (' ...args' if short.fuzzy else '')
+        target = short.command.split() if isinstance(short.command, str) else [root.header_display]
+        results.append((rendered, target))
+    return results
+
+
 def _resolve_current_subcommand(root: Alconna, sub_path: list[str]) -> list[Subcommand] | None:
     """Resolve the canonical subcommand chain along ``sub_path``.
 
@@ -130,7 +155,7 @@ class StructuredHelpFormatter(TextFormatter):
 
     @override
     def format(self, trace: Trace) -> str:
-        from .render.schemas.help import HelpData, HelpNode, HelpOption  # noqa: PLC0415
+        from .render.schemas.help import HelpData, HelpNode, HelpOption, HelpShortcut  # noqa: PLC0415
 
         head = trace.head
         # head['name'] looks like 'tstats TETR.IO|io|TETRIO query' where each
@@ -186,15 +211,16 @@ class StructuredHelpFormatter(TextFormatter):
         )
         # usage / examples / shortcuts only exist on the root Alconna's CommandMeta;
         # Subcommand has no `meta` attribute. Show them only on the root help page.
+        all_shortcuts = _collect_shortcuts(self.root)
         if not sub_path:
             usage = self.root.meta.usage
             example_raw = self.root.meta.example
             examples = [line for line in (example_raw or '').splitlines() if line.strip()]
-            shortcuts = list(self.root.get_shortcuts())
+            shortcuts = [HelpShortcut(key=k, target=t) for k, t in all_shortcuts]
         else:
             usage = None
             examples = []
-            shortcuts = []
+            shortcuts = [HelpShortcut(key=k, target=t) for k, t in all_shortcuts if t == breadcrumb]
         data = HelpData(
             lang=get_lang(),
             command=node,

--- a/nonebot_plugin_tetris_stats/utils/help_formatter.py
+++ b/nonebot_plugin_tetris_stats/utils/help_formatter.py
@@ -136,18 +136,11 @@ def _render_target_signature(root: Alconna, target: list[str]) -> str:
         children = list(sub.options)
 
     tokens: list[str] = []
-    for a in args_iter:
-        if a.hidden:
-            continue
-        tokens.append(_render_arg_token(a.name, optional=a.optional))
+    tokens.extend(_render_arg_token(a.name, optional=a.optional) for a in args_iter)
     for child in children:
         if isinstance(child, _BUILTINS) or not isinstance(child, Option):
             continue
-        inner = [child.name]
-        for a in child.args.argument:
-            if a.hidden:
-                continue
-            inner.append(_render_arg_token(a.name, optional=a.optional))
+        inner = [child.name, *(_render_arg_token(a.name, optional=a.optional) for a in child.args.argument)]
         tokens.append(f'[{" ".join(inner)}]')
     return ' '.join(tokens)
 

--- a/nonebot_plugin_tetris_stats/utils/help_formatter.py
+++ b/nonebot_plugin_tetris_stats/utils/help_formatter.py
@@ -34,6 +34,32 @@ HELP_JSON_PREFIX = '__NBPTS_HELP_V1__:'
 _BUILTINS = (Help, Completion, Shortcut)
 _EMPTY = Signature.empty
 
+# Alconna 把多别名拼进同一个名字 token, 用 U+2502 BOX DRAWINGS LIGHT VERTICAL
+# 作为分隔符 (e.g. 'TETR.IO|io|TETRIO'). 我们对外暴露 schema 时只保留主名,
+# 把剩余别名合并到 aliases 列表, 让前端不再需要做 split。
+_ALIAS_SEP = '\u2502'
+
+
+def _split_name(name: str) -> tuple[str, list[str]]:
+    """Split a U+2502-joined name into (canonical, extra_aliases)."""
+    parts = [p for p in name.split(_ALIAS_SEP) if p]
+    if not parts:
+        return name, []
+    return parts[0], parts[1:]
+
+
+def _merge_aliases(canonical: str, *alias_sources: list[str] | tuple[str, ...]) -> list[str]:
+    """Merge alias lists, drop duplicates, drop the canonical name itself."""
+    seen: set[str] = {canonical}
+    result: list[str] = []
+    for src in alias_sources:
+        for a in src:
+            if a in seen:
+                continue
+            seen.add(a)
+            result.append(a)
+    return result
+
 
 def _arg_to_help(arg: Arg) -> 'HelpArg':
     from .render.schemas.help import HelpArg  # noqa: PLC0415
@@ -73,10 +99,11 @@ def _sub_to_help(sub: Subcommand) -> 'HelpNode':
             subcommands.append(_sub_to_help(child))
         elif isinstance(child, Option):
             options.append(_opt_to_help(child))
+    canonical, name_aliases = _split_name(sub.name)
     return HelpNode(
-        name=sub.name,
+        name=canonical,
         dest=sub.dest,
-        aliases=[a for a in sub.aliases if a != sub.name],
+        aliases=_merge_aliases(canonical, name_aliases, list(sub.aliases)),
         help_text=sub.help_text,
         args=[_arg_to_help(a) for a in sub.args.argument],
         options=options,
@@ -156,15 +183,16 @@ def _collect_shortcuts(root: Alconna) -> list[tuple[str, list[str]]]:
     what they may / must supply, instead of the opaque ``...args`` placeholder.
     """
     results: list[tuple[str, list[str]]] = []
+    root_canonical, _ = _split_name(root.header_display)
     for key, short in command_manager.get_shortcut(root).items():
         if _is_easter_egg(key):
             continue
         if not isinstance(short, InnerShortcutArgs):
             # Custom shortcut wrappers: cannot statically resolve target.
-            results.append((key, [root.header_display]))
+            results.append((key, [root_canonical]))
             continue
         cmd_text = _extract_command_text(short.command)
-        target = [tok for tok in cmd_text.split() if _is_path_segment(tok)] if cmd_text else [root.header_display]
+        target = [tok for tok in cmd_text.split() if _is_path_segment(tok)] if cmd_text else [root_canonical]
         suffix = _render_target_signature(root, target)
         rendered = f'{key} {suffix}' if suffix else key
         results.append((rendered, target))
@@ -245,20 +273,27 @@ class StructuredHelpFormatter(TextFormatter):
             raise RuntimeError(msg)
 
         if not sub_path:
-            cur_name = self.root.header_display
+            root_canonical, root_name_aliases = _split_name(self.root.header_display)
+            cur_name = root_canonical
             cur_dest = self.root.path
-            cur_aliases = [str(p) for p in self.root.prefixes if p != cur_name]
-            breadcrumb = [cur_name]
+            cur_aliases = _merge_aliases(
+                root_canonical,
+                root_name_aliases,
+                [str(p) for p in self.root.prefixes],
+            )
+            breadcrumb = [root_canonical]
         else:
             chain = _resolve_current_subcommand(self.root, sub_path)
             if chain is None:
                 msg = f'cannot resolve subcommand for path {sub_path!r}'
                 raise RuntimeError(msg)
             sub = chain[-1]
-            cur_name = sub.name
+            sub_canonical, sub_name_aliases = _split_name(sub.name)
+            cur_name = sub_canonical
             cur_dest = sub.dest
-            cur_aliases = [a for a in sub.aliases if a != sub.name]
-            breadcrumb = [self.root.header_display, *(s.name for s in chain)]
+            cur_aliases = _merge_aliases(sub_canonical, sub_name_aliases, list(sub.aliases))
+            root_canonical, _ = _split_name(self.root.header_display)
+            breadcrumb = [root_canonical, *(_split_name(s.name)[0] for s in chain)]
 
         # Lazy import avoids circular dependency with games/* (render/__init__.py
         # -> host.py -> games.tetrio.api.cache -> back into games/__init__.py).

--- a/nonebot_plugin_tetris_stats/utils/help_formatter.py
+++ b/nonebot_plugin_tetris_stats/utils/help_formatter.py
@@ -287,7 +287,7 @@ class StructuredHelpFormatter(TextFormatter):
         else:
             usage = None
             examples = []
-            shortcuts = [HelpShortcut(key=k, target=t) for k, t in all_shortcuts if t == breadcrumb]
+            shortcuts = [HelpShortcut(key=k, target=t) for k, t in all_shortcuts if t[1:len(breadcrumb)] == breadcrumb[1:]]
         data = HelpData(
             lang=get_lang(),
             command=node,

--- a/nonebot_plugin_tetris_stats/utils/help_formatter.py
+++ b/nonebot_plugin_tetris_stats/utils/help_formatter.py
@@ -87,6 +87,31 @@ def _is_easter_egg(key: str) -> bool:
     return 'easter egg' in key.casefold()
 
 
+def _extract_command_text(command: object) -> str | None:
+    """Extract a plain command path string from InnerShortcutArgs.command.
+
+    The field can be either a raw ``str`` or a list of message segments
+    (e.g. ``[Text(text='tstats TETR.IO query', ...)]``) when the shortcut
+    flowed through nonebot-plugin-alconna's uniseg layer. We concatenate any
+    object that exposes a ``text`` attribute.
+    """
+    if isinstance(command, str):
+        return command
+    if isinstance(command, list):
+        parts: list[str] = []
+        for seg in command:
+            text = getattr(seg, 'text', None)
+            if isinstance(text, str):
+                parts.append(text)
+        return ' '.join(parts) if parts else None
+    return None
+
+
+def _is_path_segment(token: str) -> bool:
+    """Path segments are command/subcommand names; not flags or placeholders."""
+    return not token.startswith(('-', '{'))
+
+
 def _collect_shortcuts(root: Alconna) -> list[tuple[str, list[str]]]:
     """Return list of (humanized_key, target_path) pairs, filtering easter eggs.
 
@@ -101,7 +126,11 @@ def _collect_shortcuts(root: Alconna) -> list[tuple[str, list[str]]]:
             results.append((key, [root.header_display]))
             continue
         rendered = key + (' ...args' if short.fuzzy else '')
-        target = short.command.split() if isinstance(short.command, str) else [root.header_display]
+        cmd_text = _extract_command_text(short.command)
+        if cmd_text:
+            target = [tok for tok in cmd_text.split() if _is_path_segment(tok)]
+        else:
+            target = [root.header_display]
         results.append((rendered, target))
     return results
 

--- a/nonebot_plugin_tetris_stats/utils/help_formatter.py
+++ b/nonebot_plugin_tetris_stats/utils/help_formatter.py
@@ -1,9 +1,9 @@
 """Structured help formatter for Alconna.
 
 Overrides Alconna's built-in --help output. ``StructuredHelpFormatter.format()``
-returns a prefixed ``HelpData`` JSON string instead of human-readable text;
-``HelpImageExtension.output_converter`` later intercepts it and renders an
-image message.
+returns a ``HelpData`` JSON string instead of human-readable text;
+``HelpImageExtension.output_converter`` later intercepts it (when
+``output_type == 'help'``) and renders an image message.
 
 fail-fast: this formatter does NOT try/except internally. If node extraction
 fails, the exception is wrapped by nonebot-plugin-alconna into
@@ -26,10 +26,6 @@ from typing_extensions import Self, override
 
 if TYPE_CHECKING:
     from .render.schemas.help import HelpArg, HelpNode, HelpOption
-
-# Namespaced + versioned envelope. Both the formatter and the extension match
-# on this prefix. Future schema bumps go to V2 / V3 for graceful migration.
-HELP_JSON_PREFIX = '__NBPTS_HELP_V1__:'
 
 _BUILTINS = (Help, Completion, Shortcut)
 _EMPTY = Signature.empty
@@ -330,4 +326,4 @@ class StructuredHelpFormatter(TextFormatter):
             examples=examples,
             shortcuts=shortcuts,
         )
-        return HELP_JSON_PREFIX + (data.model_dump_json(by_alias=True) if PYDANTIC_V2 else data.json(by_alias=True))
+        return data.model_dump_json(by_alias=True) if PYDANTIC_V2 else data.json(by_alias=True)

--- a/nonebot_plugin_tetris_stats/utils/help_formatter.py
+++ b/nonebot_plugin_tetris_stats/utils/help_formatter.py
@@ -295,6 +295,4 @@ class StructuredHelpFormatter(TextFormatter):
             examples=examples,
             shortcuts=shortcuts,
         )
-        return HELP_JSON_PREFIX + (
-            data.model_dump_json(by_alias=True) if PYDANTIC_V2 else data.json(by_alias=True)
-        )
+        return HELP_JSON_PREFIX + (data.model_dump_json(by_alias=True) if PYDANTIC_V2 else data.json(by_alias=True))

--- a/nonebot_plugin_tetris_stats/utils/help_formatter.py
+++ b/nonebot_plugin_tetris_stats/utils/help_formatter.py
@@ -19,7 +19,8 @@ from arclet.alconna import Alconna, Option, Subcommand
 from arclet.alconna.args import Arg
 from arclet.alconna.base import Completion, Help, Shortcut
 from arclet.alconna.formatter import TextFormatter, Trace
-from arclet.alconna.manager import InnerShortcutArgs, command_manager
+from arclet.alconna.manager import command_manager
+from arclet.alconna.typing import InnerShortcutArgs
 from typing_extensions import Self, override
 
 if TYPE_CHECKING:
@@ -249,7 +250,7 @@ class StructuredHelpFormatter(TextFormatter):
         if not sub_path:
             cur_name = self.root.header_display
             cur_dest = self.root.path
-            cur_aliases = [p for p in self.root.prefixes if p != cur_name]
+            cur_aliases = [str(p) for p in self.root.prefixes if p != cur_name]
             breadcrumb = [cur_name]
         else:
             chain = _resolve_current_subcommand(self.root, sub_path)

--- a/nonebot_plugin_tetris_stats/utils/help_formatter.py
+++ b/nonebot_plugin_tetris_stats/utils/help_formatter.py
@@ -21,6 +21,7 @@ from arclet.alconna.base import Completion, Help, Shortcut
 from arclet.alconna.formatter import TextFormatter, Trace
 from arclet.alconna.manager import command_manager
 from arclet.alconna.typing import InnerShortcutArgs
+from nonebot.compat import PYDANTIC_V2
 from typing_extensions import Self, override
 
 if TYPE_CHECKING:
@@ -294,4 +295,6 @@ class StructuredHelpFormatter(TextFormatter):
             examples=examples,
             shortcuts=shortcuts,
         )
-        return HELP_JSON_PREFIX + data.model_dump_json(by_alias=True)
+        return HELP_JSON_PREFIX + (
+            data.model_dump_json(by_alias=True) if PYDANTIC_V2 else data.json(by_alias=True)
+        )

--- a/nonebot_plugin_tetris_stats/utils/help_formatter.py
+++ b/nonebot_plugin_tetris_stats/utils/help_formatter.py
@@ -1,0 +1,188 @@
+"""Structured help formatter for Alconna.
+
+Overrides Alconna's built-in --help output. ``StructuredHelpFormatter.format()``
+returns a prefixed ``HelpData`` JSON string instead of human-readable text;
+``HelpImageExtension.output_converter`` later intercepts it and renders an
+image message.
+
+fail-fast: this formatter does NOT try/except internally. If node extraction
+fails, the exception is wrapped by nonebot-plugin-alconna into
+``Arparma(error_info=e)`` and surfaces through the original error path so the
+problem is immediately visible. Extension/render-stage exceptions are wrapped
+in ``help_extension.py``.
+"""
+
+from inspect import Signature
+from typing import TYPE_CHECKING
+
+from arclet.alconna import Alconna, Option, Subcommand
+from arclet.alconna.args import Arg
+from arclet.alconna.base import Completion, Help, Shortcut
+from arclet.alconna.formatter import TextFormatter, Trace
+from typing_extensions import override
+
+if TYPE_CHECKING:
+    from .render.schemas.help import HelpArg, HelpNode, HelpOption
+
+# Namespaced + versioned envelope. Both the formatter and the extension match
+# on this prefix. Future schema bumps go to V2 / V3 for graceful migration.
+HELP_JSON_PREFIX = '__NBPTS_HELP_V1__:'
+
+_BUILTINS = (Help, Completion, Shortcut)
+_EMPTY = Signature.empty
+
+
+def _arg_to_help(arg: Arg) -> 'HelpArg':
+    from .render.schemas.help import HelpArg  # noqa: PLC0415
+
+    default = arg.field.default
+    return HelpArg(
+        name=arg.name,
+        notice=arg.notice,
+        type_repr=getattr(arg.value, '__name__', None) or repr(arg.value),
+        optional=arg.optional,
+        hidden=arg.hidden,
+        default=None if default is _EMPTY else repr(default),
+    )
+
+
+def _opt_to_help(opt: Option) -> 'HelpOption':
+    from .render.schemas.help import HelpOption  # noqa: PLC0415
+
+    return HelpOption(
+        name=opt.name,
+        aliases=[a for a in opt.aliases if a != opt.name],
+        dest=opt.dest,
+        args=[_arg_to_help(a) for a in opt.args.argument],
+        help_text=opt.help_text,
+    )
+
+
+def _sub_to_help(sub: Subcommand) -> 'HelpNode':
+    from .render.schemas.help import HelpNode, HelpOption  # noqa: PLC0415
+
+    options: list[HelpOption] = []
+    subcommands: list[HelpNode] = []
+    for child in sub.options:
+        if isinstance(child, _BUILTINS):
+            continue
+        if isinstance(child, Subcommand):
+            subcommands.append(_sub_to_help(child))
+        elif isinstance(child, Option):
+            options.append(_opt_to_help(child))
+    return HelpNode(
+        name=sub.name,
+        dest=sub.dest,
+        aliases=[a for a in sub.aliases if a != sub.name],
+        help_text=sub.help_text,
+        args=[_arg_to_help(a) for a in sub.args.argument],
+        options=options,
+        subcommands=subcommands,
+    )
+
+
+def _resolve_current_subcommand(root: Alconna, sub_path: list[str]) -> list[Subcommand] | None:
+    """Resolve the canonical subcommand chain along ``sub_path``.
+
+    A segment may look like ``'TETR.IO|io|TETRIO'`` (Alconna joins aliases
+    with U+2502 BOX DRAWINGS LIGHT VERTICAL in head['name']) or be a plain
+    canonical / alias / dest token. Each segment is split on U+2502 to build
+    a candidate set, then casefold-matched against every Subcommand's
+    ``name`` / ``aliases`` / ``dest``.
+
+    Returns the chain root->target on success, ``None`` if any segment fails
+    to resolve.
+    """
+    cur_options: list = list(root.options)
+    chain: list[Subcommand] = []
+    for seg in sub_path:
+        candidates_cf = {p.casefold() for p in seg.split('\u2502') if p}
+        nxt = next(
+            (
+                c
+                for c in cur_options
+                if isinstance(c, Subcommand)
+                and (
+                    c.name.casefold() in candidates_cf
+                    or c.dest.casefold() in candidates_cf
+                    or any(a.casefold() in candidates_cf for a in c.aliases)
+                )
+            ),
+            None,
+        )
+        if nxt is None:
+            return None
+        chain.append(nxt)
+        cur_options = list(nxt.options)
+    return chain
+
+
+class StructuredHelpFormatter(TextFormatter):
+    """Returns a HelpData JSON string instead of plain text help.
+
+    Caller MUST back-fill ``root`` after Alconna instantiation::
+
+        command = Alconna(..., formatter_type=StructuredHelpFormatter)
+        command.formatter.root = command  # type: ignore[attr-defined]
+    """
+
+    root: Alconna | None = None
+
+    @override
+    def format(self, trace: Trace) -> str:
+        from .render.schemas.help import HelpData, HelpNode, HelpOption  # noqa: PLC0415
+
+        head = trace.head
+        # head['name'] looks like 'tstats TETR.IO|io|TETRIO query' where each
+        # whitespace-separated segment may contain aliases joined by U+2502.
+        # The canonical name is not guaranteed to be the first alias; we
+        # therefore split into raw segments and resolve canonical Subcommand
+        # objects below.
+        raw_segments: list[str] = head['name'].split()
+        sub_path = raw_segments[1:]
+
+        options: list[HelpOption] = []
+        subcommands: list[HelpNode] = []
+        for child in trace.body:
+            if isinstance(child, _BUILTINS):
+                continue
+            if isinstance(child, Subcommand):
+                subcommands.append(_sub_to_help(child))
+            elif isinstance(child, Option):
+                options.append(_opt_to_help(child))
+
+        if self.root is None:
+            msg = 'StructuredHelpFormatter.root is not injected; back-fill command.formatter.root after Alconna(...)'
+            raise RuntimeError(msg)
+
+        if not sub_path:
+            cur_name = self.root.header_display
+            cur_dest = self.root.path
+            cur_aliases = [p for p in self.root.prefixes if p != cur_name]
+            breadcrumb = [cur_name]
+        else:
+            chain = _resolve_current_subcommand(self.root, sub_path)
+            if chain is None:
+                msg = f'cannot resolve subcommand for path {sub_path!r}'
+                raise RuntimeError(msg)
+            sub = chain[-1]
+            cur_name = sub.name
+            cur_dest = sub.dest
+            cur_aliases = [a for a in sub.aliases if a != sub.name]
+            breadcrumb = [self.root.header_display, *(s.name for s in chain)]
+
+        # Lazy import avoids circular dependency with games/* (render/__init__.py
+        # -> host.py -> games.tetrio.api.cache -> back into games/__init__.py).
+        from .lang import get_lang  # noqa: PLC0415
+
+        node = HelpNode(
+            name=cur_name,
+            dest=cur_dest,
+            aliases=cur_aliases,
+            help_text=head.get('description'),
+            args=[_arg_to_help(a) for a in trace.args],
+            options=options,
+            subcommands=subcommands,
+        )
+        data = HelpData(lang=get_lang(), command=node, breadcrumb=breadcrumb)
+        return HELP_JSON_PREFIX + data.model_dump_json(by_alias=True)

--- a/nonebot_plugin_tetris_stats/utils/help_formatter.py
+++ b/nonebot_plugin_tetris_stats/utils/help_formatter.py
@@ -184,5 +184,23 @@ class StructuredHelpFormatter(TextFormatter):
             options=options,
             subcommands=subcommands,
         )
-        data = HelpData(lang=get_lang(), command=node, breadcrumb=breadcrumb)
+        # usage / examples / shortcuts only exist on the root Alconna's CommandMeta;
+        # Subcommand has no `meta` attribute. Show them only on the root help page.
+        if not sub_path:
+            usage = self.root.meta.usage
+            example_raw = self.root.meta.example
+            examples = [line for line in (example_raw or '').splitlines() if line.strip()]
+            shortcuts = list(self.root.get_shortcuts())
+        else:
+            usage = None
+            examples = []
+            shortcuts = []
+        data = HelpData(
+            lang=get_lang(),
+            command=node,
+            breadcrumb=breadcrumb,
+            usage=usage,
+            examples=examples,
+            shortcuts=shortcuts,
+        )
         return HELP_JSON_PREFIX + data.model_dump_json(by_alias=True)

--- a/nonebot_plugin_tetris_stats/utils/render/schemas/help.py
+++ b/nonebot_plugin_tetris_stats/utils/render/schemas/help.py
@@ -41,6 +41,9 @@ class HelpData(Base):
     kind: Literal['help'] = 'help'
     command: HelpNode
     breadcrumb: list[str]
+    usage: str | None = None
+    examples: list[str] = []
+    shortcuts: list[str] = []
 
     @property
     @override

--- a/nonebot_plugin_tetris_stats/utils/render/schemas/help.py
+++ b/nonebot_plugin_tetris_stats/utils/render/schemas/help.py
@@ -1,0 +1,48 @@
+from typing import Literal
+
+from pydantic import BaseModel
+from typing_extensions import override
+
+from .base import Base
+
+
+class HelpArg(BaseModel):
+    name: str
+    notice: str | None
+    type_repr: str | None
+    optional: bool
+    hidden: bool
+    default: str | None
+
+
+class HelpOption(BaseModel):
+    name: str
+    aliases: list[str]
+    dest: str
+    args: list[HelpArg]
+    help_text: str | None
+
+
+class HelpNode(BaseModel):
+    name: str
+    dest: str
+    aliases: list[str]
+    help_text: str | None
+    args: list[HelpArg]
+    options: list[HelpOption]
+    subcommands: list['HelpNode']
+
+
+HelpNode.model_rebuild()
+
+
+class HelpData(Base):
+    schema_version: Literal[1] = 1
+    kind: Literal['help'] = 'help'
+    command: HelpNode
+    breadcrumb: list[str]
+
+    @property
+    @override
+    def path(self) -> str:
+        return 'help'

--- a/nonebot_plugin_tetris_stats/utils/render/schemas/help.py
+++ b/nonebot_plugin_tetris_stats/utils/render/schemas/help.py
@@ -54,7 +54,6 @@ class HelpShortcut(BaseModel):
 
 class HelpData(Base):
     schema_version: Literal[1] = 1
-    kind: Literal['help'] = 'help'
     command: HelpNode
     breadcrumb: list[str]
     usage: str | None = None

--- a/nonebot_plugin_tetris_stats/utils/render/schemas/help.py
+++ b/nonebot_plugin_tetris_stats/utils/render/schemas/help.py
@@ -36,6 +36,18 @@ class HelpNode(BaseModel):
 HelpNode.model_rebuild()
 
 
+class HelpShortcut(BaseModel):
+    """A shortcut binding, resolved to its canonical target path.
+
+    ``key`` is the human-readable trigger (e.g. ``"io查 ...args"``);
+    ``target`` is the canonical breadcrumb of the command it expands to,
+    e.g. ``["tstats", "TETR.IO", "query"]``.
+    """
+
+    key: str
+    target: list[str]
+
+
 class HelpData(Base):
     schema_version: Literal[1] = 1
     kind: Literal['help'] = 'help'
@@ -43,7 +55,7 @@ class HelpData(Base):
     breadcrumb: list[str]
     usage: str | None = None
     examples: list[str] = []
-    shortcuts: list[str] = []
+    shortcuts: list[HelpShortcut] = []
 
     @property
     @override

--- a/nonebot_plugin_tetris_stats/utils/render/schemas/help.py
+++ b/nonebot_plugin_tetris_stats/utils/render/schemas/help.py
@@ -1,5 +1,6 @@
 from typing import Literal
 
+from nonebot.compat import PYDANTIC_V2
 from pydantic import BaseModel
 from typing_extensions import override
 
@@ -33,7 +34,10 @@ class HelpNode(BaseModel):
     subcommands: list['HelpNode']
 
 
-HelpNode.model_rebuild()
+if PYDANTIC_V2:
+    HelpNode.model_rebuild()
+else:
+    HelpNode.update_forward_refs()
 
 
 class HelpShortcut(BaseModel):

--- a/nonebot_plugin_tetris_stats/utils/render/schemas/help.py
+++ b/nonebot_plugin_tetris_stats/utils/render/schemas/help.py
@@ -1,5 +1,3 @@
-from typing import Literal
-
 from nonebot.compat import PYDANTIC_V2
 from pydantic import BaseModel
 from typing_extensions import override
@@ -53,7 +51,6 @@ class HelpShortcut(BaseModel):
 
 
 class HelpData(Base):
-    schema_version: Literal[1] = 1
     command: HelpNode
     breadcrumb: list[str]
     usage: str | None = None

--- a/nonebot_plugin_tetris_stats/utils/render/schemas/help.py
+++ b/nonebot_plugin_tetris_stats/utils/render/schemas/help.py
@@ -1,5 +1,5 @@
 from nonebot.compat import PYDANTIC_V2
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing_extensions import override
 
 from .base import Base
@@ -54,8 +54,8 @@ class HelpData(Base):
     command: HelpNode
     breadcrumb: list[str]
     usage: str | None = None
-    examples: list[str] = []
-    shortcuts: list[HelpShortcut] = []
+    examples: list[str] = Field(default_factory=list)
+    shortcuts: list[HelpShortcut] = Field(default_factory=list)
 
     @property
     @override

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "aiocache>=0.12.3",
     "aiofiles>=24.1.0",
     "arclet-alconna<2",
+    "nepattern>=0.7.8",
     "async-lru>=2.0.4",
     "fake-useragent>=2.0.3",
     "httpx>=0.27.2",

--- a/tests/test_help_formatter.py
+++ b/tests/test_help_formatter.py
@@ -162,6 +162,16 @@ def test_resolve_unknown_path_returns_none() -> None:
         command_manager.delete(a)
 
 
+def test_alias_index_built_from_subcommands(alc: Alconna) -> None:
+    """The Extension's alias index must map every alias / dest -> canonical name."""
+    from nonebot_plugin_tetris_stats.utils.help_extension import _build_alias_index  # noqa: PLC0415
+
+    index = _build_alias_index(alc)
+    assert index['tetr.io'] == 'TETR.IO'  # canonical (casefolded)  # noqa: S101
+    assert index['io'] == 'TETR.IO'  # alias  # noqa: S101
+    assert index['tetrio'] == 'TETR.IO'  # alias + dest (casefolded)  # noqa: S101
+
+
 def test_auto_send_output_remains_true() -> None:
     """Lock the v3.1 design dependency on on_alconna(auto_send_output=True).
 

--- a/tests/test_help_formatter.py
+++ b/tests/test_help_formatter.py
@@ -27,7 +27,6 @@ def alc() -> Iterator[Alconna]:
         meta=CommandMeta(description='Tetris stats root command'),
         formatter_type=StructuredHelpFormatter,
     )
-    a.formatter.root = a  # type: ignore[attr-defined]
     yield a
     command_manager.delete(a)
 
@@ -109,7 +108,6 @@ def test_args_metadata() -> None:
         ),
         formatter_type=StructuredHelpFormatter,
     )
-    a.formatter.root = a  # type: ignore[attr-defined]
     try:
         out = _capture(a, 't sub --help')
         data = HelpData.model_validate_json(out)
@@ -144,7 +142,6 @@ def test_resolve_unknown_path_returns_none() -> None:
     )
 
     a = Alconna(['x'], Subcommand('a'), formatter_type=StructuredHelpFormatter)
-    a.formatter.root = a  # type: ignore[attr-defined]
     try:
         assert _resolve_current_subcommand(a, ['nonexist']) is None  # noqa: S101
     finally:

--- a/tests/test_help_formatter.py
+++ b/tests/test_help_formatter.py
@@ -1,0 +1,174 @@
+"""Tests for StructuredHelpFormatter and HelpData schema."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from arclet.alconna import Alconna, Args, CommandMeta, Option, Subcommand, command_manager, output_manager
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture
+def alc() -> Iterator[Alconna]:
+    from nonebot_plugin_tetris_stats.utils.help_formatter import StructuredHelpFormatter  # noqa: PLC0415
+
+    a = Alconna(
+        ['tstats'],
+        Subcommand(
+            'TETR.IO',
+            Subcommand('query', Args['account', str], help_text='query account'),
+            Option('--flag', help_text='a flag'),
+            alias=['io', 'TETRIO'],
+            help_text='TETR.IO related',
+        ),
+        meta=CommandMeta(description='Tetris stats root command'),
+        formatter_type=StructuredHelpFormatter,
+    )
+    a.formatter.root = a  # type: ignore[attr-defined]
+    yield a
+    command_manager.delete(a)
+
+
+def _capture(alc: Alconna, cmd: str) -> str:
+    captured: list[str] = []
+
+    def action(text: str) -> None:
+        captured.append(text)
+
+    with output_manager.capture(alc.header_display) as cap:
+        output_manager.set_action(action, command=alc.header_display)
+        alc.parse(cmd)
+    if captured:
+        return captured[-1]
+    out = cap.get('output')
+    assert out is not None, f'no output captured for {cmd!r}'  # noqa: S101
+    return out
+
+
+def test_envelope_prefix_and_schema(alc: Alconna) -> None:
+    from nonebot_plugin_tetris_stats.utils.help_formatter import HELP_JSON_PREFIX  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
+
+    out = _capture(alc, 'tstats --help')
+    assert out.startswith(HELP_JSON_PREFIX)  # noqa: S101
+    data = HelpData.model_validate_json(out[len(HELP_JSON_PREFIX) :])
+    assert data.schema_version == 1  # noqa: S101
+    assert data.kind == 'help'  # noqa: S101
+    assert data.breadcrumb == ['tstats']  # noqa: S101
+
+
+def test_root_node_metadata(alc: Alconna) -> None:
+    from nonebot_plugin_tetris_stats.utils.help_formatter import HELP_JSON_PREFIX  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
+
+    out = _capture(alc, 'tstats --help')
+    data = HelpData.model_validate_json(out[len(HELP_JSON_PREFIX) :])
+    assert data.command.name == 'tstats'  # noqa: S101
+    assert data.command.help_text == 'Tetris stats root command'  # noqa: S101
+    sub_names = {s.name for s in data.command.subcommands}
+    assert 'TETR.IO' in sub_names  # noqa: S101
+
+
+def test_subcommand_metadata_includes_aliases(alc: Alconna) -> None:
+    """Subcommand node must expose canonical name + full aliases.
+
+    Note: Alconna upstream does not match alias strings as the subcommand
+    trigger token (probe confirmed 'tstats io --help' does NOT enter the
+    subcommand). We therefore trigger via the canonical name, but the schema
+    must still expose all aliases.
+    """
+    from nonebot_plugin_tetris_stats.utils.help_formatter import HELP_JSON_PREFIX  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
+
+    out = _capture(alc, 'tstats TETR.IO --help')
+    data = HelpData.model_validate_json(out[len(HELP_JSON_PREFIX) :])
+    assert data.command.name == 'TETR.IO'  # noqa: S101
+    assert set(data.command.aliases) == {'io', 'TETRIO'}  # noqa: S101
+    assert data.command.help_text == 'TETR.IO related'  # noqa: S101
+    assert data.breadcrumb == ['tstats', 'TETR.IO']  # noqa: S101
+
+
+def test_deep_subcommand(alc: Alconna) -> None:
+    from nonebot_plugin_tetris_stats.utils.help_formatter import HELP_JSON_PREFIX  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
+
+    out = _capture(alc, 'tstats TETR.IO query --help')
+    data = HelpData.model_validate_json(out[len(HELP_JSON_PREFIX) :])
+    assert data.breadcrumb == ['tstats', 'TETR.IO', 'query']  # noqa: S101
+    assert data.command.name == 'query'  # noqa: S101
+    assert data.command.help_text == 'query account'  # noqa: S101
+    assert [a.name for a in data.command.args] == ['account']  # noqa: S101
+
+
+def test_args_metadata() -> None:
+    from nonebot_plugin_tetris_stats.utils.help_formatter import (  # noqa: PLC0415
+        HELP_JSON_PREFIX,
+        StructuredHelpFormatter,
+    )
+    from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
+
+    a = Alconna(
+        ['t'],
+        Subcommand(
+            'sub',
+            Args['x;?#X notice', int, 42]['y;/', str],
+            help_text='sub help',
+        ),
+        formatter_type=StructuredHelpFormatter,
+    )
+    a.formatter.root = a  # type: ignore[attr-defined]
+    try:
+        out = _capture(a, 't sub --help')
+        data = HelpData.model_validate_json(out[len(HELP_JSON_PREFIX) :])
+        args_by_name = {arg.name: arg for arg in data.command.args}
+        x = args_by_name['x']
+        assert x.optional is True  # noqa: S101
+        assert x.notice == 'X notice'  # noqa: S101
+        assert x.default == '42'  # noqa: S101
+        y = args_by_name['y']
+        assert y.hidden is True  # noqa: S101
+    finally:
+        command_manager.delete(a)
+
+
+def test_builtins_filtered(alc: Alconna) -> None:
+    """Help / Completion / Shortcut nodes must not appear in options."""
+    from nonebot_plugin_tetris_stats.utils.help_formatter import HELP_JSON_PREFIX  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
+
+    out = _capture(alc, 'tstats --help')
+    data = HelpData.model_validate_json(out[len(HELP_JSON_PREFIX) :])
+    opt_names = {o.name for o in data.command.options}
+    assert '--help' not in opt_names  # noqa: S101
+    assert '--shortcut' not in opt_names  # noqa: S101
+    assert '--comp' not in opt_names  # noqa: S101
+
+
+def test_resolve_unknown_path_returns_none() -> None:
+    """Mismatched command tree / breadcrumb is a real bug; must fail-fast."""
+    from nonebot_plugin_tetris_stats.utils.help_formatter import (  # noqa: PLC0415
+        StructuredHelpFormatter,
+        _resolve_current_subcommand,
+    )
+
+    a = Alconna(['x'], Subcommand('a'), formatter_type=StructuredHelpFormatter)
+    a.formatter.root = a  # type: ignore[attr-defined]
+    try:
+        assert _resolve_current_subcommand(a, ['nonexist']) is None  # noqa: S101
+    finally:
+        command_manager.delete(a)
+
+
+def test_auto_send_output_remains_true() -> None:
+    """Lock the v3.1 design dependency on on_alconna(auto_send_output=True).
+
+    If this is ever turned off, HelpImageExtension.output_converter never
+    fires and help images silently stop being sent.
+    """
+    from nonebot_plugin_tetris_stats.games import alc  # noqa: PLC0415
+
+    rule = next(c for c in alc.rule.checkers if c.call.__class__.__name__ == 'AlconnaRule')
+    assert rule.call.auto_send is True  # type: ignore[attr-defined]  # noqa: S101

--- a/tests/test_help_formatter.py
+++ b/tests/test_help_formatter.py
@@ -47,14 +47,6 @@ def _capture(alc: Alconna, cmd: str) -> str:
     return out
 
 
-def test_output_is_valid_help_data(alc: Alconna) -> None:
-    from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
-
-    out = _capture(alc, 'tstats --help')
-    data = HelpData.model_validate_json(out)
-    assert data.breadcrumb == ['tstats']  # noqa: S101
-
-
 def test_root_node_metadata(alc: Alconna) -> None:
     from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
 

--- a/tests/test_help_formatter.py
+++ b/tests/test_help_formatter.py
@@ -48,24 +48,19 @@ def _capture(alc: Alconna, cmd: str) -> str:
     return out
 
 
-def test_envelope_prefix_and_schema(alc: Alconna) -> None:
-    from nonebot_plugin_tetris_stats.utils.help_formatter import HELP_JSON_PREFIX  # noqa: PLC0415
+def test_output_is_valid_help_data(alc: Alconna) -> None:
     from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
 
     out = _capture(alc, 'tstats --help')
-    assert out.startswith(HELP_JSON_PREFIX)  # noqa: S101
-    data = HelpData.model_validate_json(out[len(HELP_JSON_PREFIX) :])
-    assert data.schema_version == 1  # noqa: S101
-    assert data.kind == 'help'  # noqa: S101
+    data = HelpData.model_validate_json(out)
     assert data.breadcrumb == ['tstats']  # noqa: S101
 
 
 def test_root_node_metadata(alc: Alconna) -> None:
-    from nonebot_plugin_tetris_stats.utils.help_formatter import HELP_JSON_PREFIX  # noqa: PLC0415
     from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
 
     out = _capture(alc, 'tstats --help')
-    data = HelpData.model_validate_json(out[len(HELP_JSON_PREFIX) :])
+    data = HelpData.model_validate_json(out)
     assert data.command.name == 'tstats'  # noqa: S101
     assert data.command.help_text == 'Tetris stats root command'  # noqa: S101
     sub_names = {s.name for s in data.command.subcommands}
@@ -80,11 +75,10 @@ def test_subcommand_metadata_includes_aliases(alc: Alconna) -> None:
     subcommand). We therefore trigger via the canonical name, but the schema
     must still expose all aliases.
     """
-    from nonebot_plugin_tetris_stats.utils.help_formatter import HELP_JSON_PREFIX  # noqa: PLC0415
     from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
 
     out = _capture(alc, 'tstats TETR.IO --help')
-    data = HelpData.model_validate_json(out[len(HELP_JSON_PREFIX) :])
+    data = HelpData.model_validate_json(out)
     assert data.command.name == 'TETR.IO'  # noqa: S101
     assert set(data.command.aliases) == {'io', 'TETRIO'}  # noqa: S101
     assert data.command.help_text == 'TETR.IO related'  # noqa: S101
@@ -92,11 +86,10 @@ def test_subcommand_metadata_includes_aliases(alc: Alconna) -> None:
 
 
 def test_deep_subcommand(alc: Alconna) -> None:
-    from nonebot_plugin_tetris_stats.utils.help_formatter import HELP_JSON_PREFIX  # noqa: PLC0415
     from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
 
     out = _capture(alc, 'tstats TETR.IO query --help')
-    data = HelpData.model_validate_json(out[len(HELP_JSON_PREFIX) :])
+    data = HelpData.model_validate_json(out)
     assert data.breadcrumb == ['tstats', 'TETR.IO', 'query']  # noqa: S101
     assert data.command.name == 'query'  # noqa: S101
     assert data.command.help_text == 'query account'  # noqa: S101
@@ -104,10 +97,7 @@ def test_deep_subcommand(alc: Alconna) -> None:
 
 
 def test_args_metadata() -> None:
-    from nonebot_plugin_tetris_stats.utils.help_formatter import (  # noqa: PLC0415
-        HELP_JSON_PREFIX,
-        StructuredHelpFormatter,
-    )
+    from nonebot_plugin_tetris_stats.utils.help_formatter import StructuredHelpFormatter  # noqa: PLC0415
     from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
 
     a = Alconna(
@@ -122,7 +112,7 @@ def test_args_metadata() -> None:
     a.formatter.root = a  # type: ignore[attr-defined]
     try:
         out = _capture(a, 't sub --help')
-        data = HelpData.model_validate_json(out[len(HELP_JSON_PREFIX) :])
+        data = HelpData.model_validate_json(out)
         args_by_name = {arg.name: arg for arg in data.command.args}
         x = args_by_name['x']
         assert x.optional is True  # noqa: S101
@@ -136,11 +126,10 @@ def test_args_metadata() -> None:
 
 def test_builtins_filtered(alc: Alconna) -> None:
     """Help / Completion / Shortcut nodes must not appear in options."""
-    from nonebot_plugin_tetris_stats.utils.help_formatter import HELP_JSON_PREFIX  # noqa: PLC0415
     from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
 
     out = _capture(alc, 'tstats --help')
-    data = HelpData.model_validate_json(out[len(HELP_JSON_PREFIX) :])
+    data = HelpData.model_validate_json(out)
     opt_names = {o.name for o in data.command.options}
     assert '--help' not in opt_names  # noqa: S101
     assert '--shortcut' not in opt_names  # noqa: S101

--- a/tests/test_help_formatter.py
+++ b/tests/test_help_formatter.py
@@ -148,15 +148,3 @@ def test_alias_index_built_from_subcommands(alc: Alconna) -> None:
     assert index['tetr.io'] == 'TETR.IO'  # canonical (casefolded)  # noqa: S101
     assert index['io'] == 'TETR.IO'  # alias  # noqa: S101
     assert index['tetrio'] == 'TETR.IO'  # alias + dest (casefolded)  # noqa: S101
-
-
-def test_auto_send_output_remains_true() -> None:
-    """Lock the v3.1 design dependency on on_alconna(auto_send_output=True).
-
-    If this is ever turned off, HelpImageExtension.output_converter never
-    fires and help images silently stop being sent.
-    """
-    from nonebot_plugin_tetris_stats.games import alc  # noqa: PLC0415
-
-    rule = next(c for c in alc.rule.checkers if c.call.__class__.__name__ == 'AlconnaRule')
-    assert rule.call.auto_send is True  # type: ignore[attr-defined]  # noqa: S101

--- a/tests/tetrio/test_bind.py
+++ b/tests/tetrio/test_bind.py
@@ -15,5 +15,4 @@ async def test_invalid_name(app: App) -> None:
     async with app.test_matcher(alc) as ctx:
         bot = ctx.create_bot()
         ctx.receive_event(bot, event)
-        ctx.should_finished(alc)
         ctx.should_call_send(event, '用户名/ID不合法', result=None)

--- a/uv.lock
+++ b/uv.lock
@@ -2535,15 +2535,15 @@ wheels = [
 
 [[package]]
 name = "nepattern"
-version = "0.7.7"
+version = "0.7.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tarina" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/36/6b551ad46d6d90341c059aade07cdaf7754838fa870da2631c1d0dd53bad/nepattern-0.7.7.tar.gz", hash = "sha256:6667f888457e78937998f9412eb70ad16d220464d2d77850dd2b05e9ecfb3207", size = 20968, upload-time = "2024-11-21T11:03:16.076Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/22/1c6443bdb0b8d121ef66e011d7b3826e119e68c89b41c1ebc8651b773cb6/nepattern-0.7.8.tar.gz", hash = "sha256:a2e20440be72a500ed7d57f28d010ac3654ae691c189b757f1ae01e33b3df57b", size = 21097, upload-time = "2026-05-04T16:53:04.237Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/74/d2ea0ed5eed9efb00e54ae2f2cb67878e64ed997cfcdc616b88d9213b373/nepattern-0.7.7-py3-none-any.whl", hash = "sha256:2d66f964333f42df7971390da4fb98dfed1e8b769236f305c28a83c0bcda849a", size = 25992, upload-time = "2024-11-21T11:03:14.202Z" },
+    { url = "https://files.pythonhosted.org/packages/73/39/9dccdc7d9a3d9966b9502122b381efda198d6de36a9c508c48a28986202b/nepattern-0.7.8-py3-none-any.whl", hash = "sha256:59fe29954b2bf8661ebca089a90977d7ca743cd6a696f4c829f97efe6fe59004", size = 26126, upload-time = "2026-05-04T16:53:02.695Z" },
 ]
 
 [[package]]
@@ -2759,6 +2759,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "lxml" },
     { name = "msgspec" },
+    { name = "nepattern" },
     { name = "nonebot-plugin-alconna" },
     { name = "nonebot-plugin-apscheduler" },
     { name = "nonebot-plugin-localstore" },
@@ -2827,6 +2828,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.4" },
     { name = "lxml", specifier = ">=5.3.0" },
     { name = "msgspec", specifier = ">=0.18.6" },
+    { name = "nepattern", specifier = ">=0.7.8" },
     { name = "nonebot-plugin-alconna", specifier = ">=0.53.1" },
     { name = "nonebot-plugin-apscheduler", specifier = ">=0.5.0" },
     { name = "nonebot-plugin-localstore", specifier = ">=0.7.1" },


### PR DESCRIPTION
## 改动概述

将 `--help` 输出从纯文本切到结构化 JSON，再由前端模板渲染为图片。

### 新增

- `utils/help_formatter.py`: `StructuredHelpFormatter` 覆盖 Alconna 默认 `TextFormatter`，直接输出 `HelpData` JSON
- `utils/help_extension.py`: `HelpImageExtension`
  - `receive_wrapper`: `--help` / `-h` 命中时把 alias 子命令 token 改写成 canonical 名称，让 Alconna 正确路由
  - `output_converter`: 拦截 help JSON 输出，解码后调 `render_image` 生成图片
- help schema 增补 `usage` / `examples` / `shortcuts` 字段
  - 快捷指令按一级子命令分组，子命令页只显示自家相关条目
  - 解析 `InnerShortcutArgs.command` 的 uniseg Text 段还原 target 路径
  - 隐藏 humanized key 含 'easter egg' 的快捷指令
  - 用 `<required>` / `[optional]` 渲染 Arg 占位符
- 接入到根 `Alconna`（`games/__init__.py`）+ `HelpImageExtension` 注册到 `on_alconna`
- `tests/test_help_formatter.py`: 覆盖 formatter 输出结构、子命令解析、别名索引等

### 修复 / 调整

- `tetrio/rank`: 统一 `--detail` / `--all` 为 `Subcommand`
- 修复 `iorank --help` 被 shortcut regex 吞掉的问题
- 修复子命令 breadcrumb 前缀匹配
- 为缺少 `notice` 的 `Arg` 补充可读说明

## 配套前端

[A-Minos/tetris-stats-templates-new#22](https://github.com/A-Minos/tetris-stats-templates-new/pull/22) 渲染本次输出的 `HelpData`。

## 兼容性

- `HelpImageExtension.output_converter` 尝试 `HelpData.model_validate_json` 解析输出，解析失败时返回空 `UniMessage`，fallback 到原文本，不影响 shortcut/completion/error 输出
- 依赖 `on_alconna(auto_send_output=True)`，关闭后图片消息不会发出
