### PR TITLE
🐛 仅对未验证绑定显示警告

### DIFF
--- a/nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py
@@ -122,7 +122,7 @@ async def _(  # noqa: PLR0913, PLR0917
         result = await make_query_result(player, template or 'v1', compare_delta)
         warning = UniMessage.i18n(Lang.interaction.warning.unverified) if not bind.verify else UniMessage()
         if not bind.verify and not result.has(Image):
-            warning += UniMessage('\n')
+            warning += '\n'
         await (warning + result).finish()
 
 

--- a/nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py
@@ -119,15 +119,11 @@ async def _(  # noqa: PLR0913, PLR0917
         if bind is None:
             await matcher.finish(Lang.bind.not_found())
         player = Player(user_id=bind.game_account, trust=True)
-        await (
-            UniMessage.i18n(Lang.interaction.warning.unverified)
-            + (
-                UniMessage('\n')
-                if not (result := await make_query_result(player, template or 'v1', compare_delta)).has(Image)
-                else UniMessage()
-            )
-            + result
-        ).finish()
+        result = await make_query_result(player, template or 'v1', compare_delta)
+        warning = UniMessage.i18n(Lang.interaction.warning.unverified) if not bind.verify else UniMessage()
+        if not bind.verify and not result.has(Image):
+            warning += UniMessage('\n')
+        await (warning + result).finish()
 
 
 @alc.assign('TETRIO.query')

--- a/nonebot_plugin_tetris_stats/games/tetrio/record/blitz.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/record/blitz.py
@@ -60,7 +60,8 @@ async def _(
             await matcher.finish(Lang.bind.not_found())
         player = Player(user_id=bind.game_account, trust=True)
         await (
-            UniMessage.i18n(Lang.interaction.warning.unverified) + UniMessage.image(raw=await make_blitz_image(player))
+            (UniMessage.i18n(Lang.interaction.warning.unverified) if not bind.verify else UniMessage())
+            + UniMessage.image(raw=await make_blitz_image(player))
         ).finish()
 
 

--- a/nonebot_plugin_tetris_stats/games/tetrio/record/sprint.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/record/sprint.py
@@ -60,7 +60,8 @@ async def _(
             await matcher.finish(Lang.bind.not_found())
         player = Player(user_id=bind.game_account, trust=True)
         await (
-            UniMessage.i18n(Lang.interaction.warning.unverified) + UniMessage.image(raw=await make_sprint_image(player))
+            (UniMessage.i18n(Lang.interaction.warning.unverified) if not bind.verify else UniMessage())
+            + UniMessage.image(raw=await make_sprint_image(player))
         ).finish()
 
 

--- a/nonebot_plugin_tetris_stats/games/top/query.py
+++ b/nonebot_plugin_tetris_stats/games/top/query.py
@@ -110,15 +110,11 @@ async def _(  # noqa: PLR0913, PLR0917
                 profile.user_name,
                 datetime.now(tz=UTC) - compare_delta,
             )
-        await (
-            UniMessage.i18n(Lang.interaction.warning.unverified)
-            + (
-                UniMessage('\n')
-                if not (result := await make_query_result(profile, compare_profile)).has(Image)
-                else UniMessage()
-            )
-            + result
-        ).finish()
+        result = await make_query_result(profile, compare_profile)
+        warning = UniMessage.i18n(Lang.interaction.warning.unverified) if not bind.verify else UniMessage()
+        if not bind.verify and not result.has(Image):
+            warning += UniMessage('\n')
+        await (warning + result).finish()
 
 
 @alc.assign('TOP.query')

--- a/nonebot_plugin_tetris_stats/games/top/query.py
+++ b/nonebot_plugin_tetris_stats/games/top/query.py
@@ -113,7 +113,7 @@ async def _(  # noqa: PLR0913, PLR0917
         result = await make_query_result(profile, compare_profile)
         warning = UniMessage.i18n(Lang.interaction.warning.unverified) if not bind.verify else UniMessage()
         if not bind.verify and not result.has(Image):
-            warning += UniMessage('\n')
+            warning += '\n'
         await (warning + result).finish()
 
 

--- a/nonebot_plugin_tetris_stats/games/tos/query.py
+++ b/nonebot_plugin_tetris_stats/games/tos/query.py
@@ -153,7 +153,7 @@ async def _(  # noqa: PLR0913, PLR0917
         )
         warning = UniMessage.i18n(Lang.interaction.warning.unverified) if not bind.verify else UniMessage()
         if not bind.verify and not result.has(Image):
-            warning += UniMessage('\n')
+            warning += '\n'
         await (warning + result).finish()
 
 

--- a/nonebot_plugin_tetris_stats/games/tos/query.py
+++ b/nonebot_plugin_tetris_stats/games/tos/query.py
@@ -146,21 +146,15 @@ async def _(  # noqa: PLR0913, PLR0917
         if bind is None:
             await matcher.finish(Lang.bind.not_found())
         player = Player(teaid=bind.game_account, trust=True)
-        await (
-            UniMessage.i18n(Lang.interaction.warning.unverified)
-            + (
-                UniMessage('\n')
-                if not (
-                    result := await make_query_result(
-                        player,
-                        await resolve_compare_delta(TOSUserConfig, session, user.id, compare),
-                        None if isinstance(who, At) else event_session.user,
-                    )
-                ).has(Image)
-                else UniMessage()
-            )
-            + result
-        ).finish()
+        result = await make_query_result(
+            player,
+            await resolve_compare_delta(TOSUserConfig, session, user.id, compare),
+            None if isinstance(who, At) else event_session.user,
+        )
+        warning = UniMessage.i18n(Lang.interaction.warning.unverified) if not bind.verify else UniMessage()
+        if not bind.verify and not result.has(Image):
+            warning += UniMessage('\n')
+        await (warning + result).finish()
 
 
 @alc.assign('TOS.query')

--- a/tests/tetrio/test_query_warning.py
+++ b/tests/tetrio/test_query_warning.py
@@ -1,0 +1,88 @@
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from tests.fake_event import FakeGroupMessageEvent
+
+if TYPE_CHECKING:
+    from nonebot.adapters import Event
+    from nonebot.matcher import Matcher
+    from nonebot_plugin_uninfo.model import Session as UninfoSession
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('case', [(False, True), (True, False)])
+async def test_bound_query_warns_only_for_unverified_account(
+    monkeypatch: pytest.MonkeyPatch,
+    case: tuple[bool, bool],
+) -> None:
+    from nonebot.adapters.onebot.v11 import Message  # noqa: PLC0415
+    from nonebot_plugin_alconna.uniseg import UniMessage  # noqa: PLC0415
+    from nonebot_plugin_alconna.uniseg.segment import I18n  # noqa: PLC0415
+    from nonebot_plugin_user.models import User  # noqa: PLC0415
+
+    from nonebot_plugin_tetris_stats.db.models import Bind  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.games import alc  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.games.tetrio import query  # noqa: PLC0415
+
+    verified, expects_warning = case
+    bind = Bind(user_id=1, game_platform='IO', game_account='tester', verify=verified)
+    user = User()
+    user.id = 1
+    sent: list[UniMessage] = []
+
+    @asynccontextmanager
+    async def fake_trigger(**_: object) -> AsyncIterator[None]:
+        yield
+
+    @asynccontextmanager
+    async def fake_get_session() -> AsyncIterator[object]:
+        yield object()
+
+    async def fake_get_session_persist_id(_: object) -> int:
+        return 1
+
+    async def fake_get_user(*_: object) -> User:
+        return user
+
+    async def fake_query_bind_info(**_: object) -> Bind:
+        return bind
+
+    async def fake_resolve_compare_delta(*_: object) -> timedelta:
+        return timedelta()
+
+    async def fake_make_query_result(*_: object) -> UniMessage:
+        return UniMessage('result')
+
+    async def capture_finish(self: UniMessage, *_: object, **__: object) -> None:
+        sent.append(self)
+
+    monkeypatch.setattr(query, 'trigger', fake_trigger)
+    monkeypatch.setattr(query, 'get_session', fake_get_session)
+    monkeypatch.setattr(query, 'get_session_persist_id', fake_get_session_persist_id)
+    monkeypatch.setattr(query, 'get_user', fake_get_user)
+    monkeypatch.setattr(query, 'query_bind_info', fake_query_bind_info)
+    monkeypatch.setattr(query, 'resolve_compare_delta', fake_resolve_compare_delta)
+    monkeypatch.setattr(query, 'make_query_result', fake_make_query_result)
+    monkeypatch.setattr(UniMessage, 'finish', capture_finish)
+
+    bound_query_handler = next(handler.call for handler in alc.handlers if handler.call.__module__ == query.__name__)
+    raw_message = 'tstats tetrio query 我'
+    message = Message(raw_message)
+    event = FakeGroupMessageEvent(message=message, original_message=message, raw_message=raw_message)
+
+    await bound_query_handler(
+        user=user,
+        event=cast('Event', event),
+        matcher=cast('Matcher', SimpleNamespace()),
+        who='我',
+        event_session=cast('UninfoSession', SimpleNamespace(scope='qq')),
+        template='v2',
+    )
+
+    assert len(sent) == 1  # noqa: S101
+    assert any(isinstance(segment, I18n) for segment in sent[0]) is expects_warning  # noqa: S101


### PR DESCRIPTION
## 问题

通过绑定查询游戏账号时，五个查询处理器都会无条件附加“无法验证绑定信息”警告，即使 TETR.IO 绑定已经通过 Discord connection 验证。查询侧没有读取已有的 `Bind.verify` 状态。

## 修改

- 仅在 `bind.verify` 为 `false` 时附加未验证警告
- 保留未验证文本结果中警告与正文之间的换行，已验证结果不产生多余换行
- 覆盖 TETR.IO query、blitz、sprint、TOP query 和 TOS query
- 通过实际注册的 TETR.IO query handler 回归验证已验证与未验证两种输出

关联 #64。TOP/TOS 目前没有写入已验证状态的流程，因此其现有行为保持不变。

## 验证

- `uv run pytest tests/tetrio/test_query_warning.py tests/tetrio/test_bind.py -q`
- `uv run ruff check tests/tetrio/test_query_warning.py nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py nonebot_plugin_tetris_stats/games/tetrio/record/blitz.py nonebot_plugin_tetris_stats/games/tetrio/record/sprint.py nonebot_plugin_tetris_stats/games/top/query.py nonebot_plugin_tetris_stats/games/tos/query.py`
- `uv run basedpyright tests/tetrio/test_query_warning.py nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py nonebot_plugin_tetris_stats/games/tetrio/record/blitz.py nonebot_plugin_tetris_stats/games/tetrio/record/sprint.py nonebot_plugin_tetris_stats/games/top/query.py nonebot_plugin_tetris_stats/games/tos/query.py`