### PR TITLE
✨ 为 TETR.IO list 增加多指标排名

### DIFF
--- a/nonebot_plugin_tetris_stats/games/tetrio/exception.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/exception.py
@@ -1,0 +1,5 @@
+from ...utils.exception import NeedCatchError
+
+
+class LeagueSnapshotNotFoundError(NeedCatchError):
+    """No persisted TETR.IO league snapshot is available."""

--- a/nonebot_plugin_tetris_stats/games/tetrio/list.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/list.py
@@ -2,6 +2,7 @@ from typing import Annotated
 
 from nonebot_plugin_alconna import Args, Option, Subcommand
 from nonebot_plugin_alconna.uniseg import UniMessage
+from nonebot_plugin_orm import get_session
 from nonebot_plugin_uninfo import Uninfo
 from nonebot_plugin_uninfo.orm import get_session_persist_id
 
@@ -12,11 +13,8 @@ from ...utils.render import render_image
 from ...utils.render.schemas.v2.tetrio.user.list import Data, List, TetraLeague, User
 from .. import alc
 from . import command
-from .api.leaderboards import by
-from .api.schemas.base import P
-from .api.schemas.leaderboards import Parameter
-from .api.schemas.leaderboards.by import Entry
 from .constant import GAME_TYPE
+from .rank.snapshot import LeagueListQuery, ListSort, query_league_list
 
 command.add(
     Subcommand(
@@ -31,18 +29,20 @@ command.add(
             help_text='查询数量',
         ),
         Option('--country', Args['country', str], help_text='国家代码'),
+        Option('--sort', Args['sort', ListSort], help_text='排名指标'),
         help_text='查询 TETR.IO 段位排行榜',
     )
 )
 
 
 @alc.assign('TETRIO.list')
-async def _(
+async def _(  # noqa: PLR0913, PLR0917
     event_session: Uninfo,
     max_tr: float | None = None,
     min_tr: float | None = None,
     limit: int | None = None,
     country: str | None = None,
+    sort: ListSort | None = None,
 ):
     country = country.upper() if country is not None else None
     async with trigger(
@@ -52,19 +52,24 @@ async def _(
         command_args=[
             f'{key} {value}'
             for key, value in zip(
-                ('--max-tr', '--min-tr', '--limit', '--country'), (max_tr, min_tr, limit, country), strict=True
+                ('--max-tr', '--min-tr', '--limit', '--country', '--sort'),
+                (max_tr, min_tr, limit, country, sort),
+                strict=True,
             )
             if value is not None
         ],
     ):
-        parameter = Parameter(
-            # ?: 似乎是只需要 pri 至少 league 榜的返回值只有 pri
-            after=P(pri=max_tr, sec=0, ter=0).to_prisecter() if max_tr is not None else None,
-            before=P(pri=min_tr, sec=0, ter=0).to_prisecter() if min_tr is not None else None,
-            limit=limit or 25,
-            country=country,
-        )
-        league = await by('league', parameter)
+        async with get_session() as session:
+            entries = await query_league_list(
+                session,
+                LeagueListQuery(
+                    sort=sort or 'league',
+                    max_tr=max_tr,
+                    min_tr=min_tr,
+                    limit=limit or 25,
+                    country=country,
+                ),
+            )
         await UniMessage.image(
             raw=await render_image(
                 List(
@@ -72,27 +77,32 @@ async def _(
                     data=[
                         Data(
                             user=User(
-                                id=i.id,
-                                name=i.username.upper(),
-                                avatar=f'https://tetr.io/user-content/avatars/{i.id}.jpg',
-                                country=i.country,
-                                xp=i.xp,
+                                id=entry.id,
+                                name=entry.username.upper(),
+                                avatar=f'https://tetr.io/user-content/avatars/{entry.id}.jpg',
+                                country=entry.country,
+                                xp=entry.xp,
                             ),
                             tetra_league=TetraLeague(
-                                rank=i.league.rank,
-                                tr=round(i.league.tr, 2),
-                                glicko=round(i.league.glicko, 2),
-                                rd=round(i.league.rd, 2),
-                                decaying=i.league.decaying,
-                                pps=(metrics := get_metrics(pps=i.league.pps, apm=i.league.apm, vs=i.league.vs)).pps,
+                                rank=entry.league.rank,
+                                tr=round(entry.league.tr, 2),
+                                glicko=round(entry.league.glicko, 2),
+                                rd=round(entry.league.rd, 2),
+                                decaying=entry.league.decaying,
+                                pps=(
+                                    metrics := get_metrics(
+                                        pps=entry.league.pps,
+                                        apm=entry.league.apm,
+                                        vs=entry.league.vs,
+                                    )
+                                ).pps,
                                 apm=metrics.apm,
                                 apl=metrics.apl,
                                 vs=metrics.vs,
                                 adpl=metrics.adpl,
                             ),
                         )
-                        for i in league.data.entries
-                        if isinstance(i, Entry)
+                        for entry in entries
                     ],
                     lang=get_lang(),
                 ),

--- a/nonebot_plugin_tetris_stats/games/tetrio/list.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/list.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 from nonebot_plugin_alconna import Args, Option, Subcommand
 from nonebot_plugin_alconna.uniseg import UniMessage
@@ -13,8 +13,15 @@ from ...utils.render import render_image
 from ...utils.render.schemas.v2.tetrio.user.list import Data, List, TetraLeague, User
 from .. import alc
 from . import command
+from .api.leaderboards import by
+from .api.schemas.base import P
+from .api.schemas.leaderboards import Parameter
+from .api.schemas.leaderboards.by import Entry, InvalidEntry
 from .constant import GAME_TYPE
 from .rank.snapshot import LeagueListQuery, ListSort, query_league_list
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 command.add(
     Subcommand(
@@ -45,6 +52,7 @@ async def _(  # noqa: PLR0913, PLR0917
     sort: ListSort | None = None,
 ):
     country = country.upper() if country is not None else None
+    sort_value = sort or 'league'
     async with trigger(
         session_persist_id=await get_session_persist_id(event_session),
         game_platform=GAME_TYPE,
@@ -59,17 +67,28 @@ async def _(  # noqa: PLR0913, PLR0917
             if value is not None
         ],
     ):
-        async with get_session() as session:
-            entries = await query_league_list(
-                session,
-                LeagueListQuery(
-                    sort=sort or 'league',
-                    max_tr=max_tr,
-                    min_tr=min_tr,
-                    limit=limit or 25,
-                    country=country,
-                ),
+        entries: Sequence[Entry | InvalidEntry]
+        if sort_value == 'league':
+            parameter = Parameter(
+                # ?: 似乎是只需要 pri 至少 league 榜的返回值只有 pri
+                after=P(pri=max_tr, sec=0, ter=0).to_prisecter() if max_tr is not None else None,
+                before=P(pri=min_tr, sec=0, ter=0).to_prisecter() if min_tr is not None else None,
+                limit=limit or 25,
+                country=country,
             )
+            entries = (await by('league', parameter)).data.entries
+        else:
+            async with get_session() as session:
+                entries = await query_league_list(
+                    session,
+                    LeagueListQuery(
+                        sort=sort_value,
+                        max_tr=max_tr,
+                        min_tr=min_tr,
+                        limit=limit or 25,
+                        country=country,
+                    ),
+                )
         await UniMessage.image(
             raw=await render_image(
                 List(
@@ -103,6 +122,7 @@ async def _(  # noqa: PLR0913, PLR0917
                             ),
                         )
                         for entry in entries
+                        if isinstance(entry, Entry)
                     ],
                     lang=get_lang(),
                 ),

--- a/nonebot_plugin_tetris_stats/games/tetrio/list.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/list.py
@@ -18,7 +18,8 @@ from .api.schemas.base import P
 from .api.schemas.leaderboards import Parameter
 from .api.schemas.leaderboards.by import Entry, InvalidEntry
 from .constant import GAME_TYPE
-from .rank.snapshot import LeagueListQuery, ListSort, query_league_list
+from .rank.snapshot import LeagueListQuery, query_league_list
+from .typedefs import ListSort
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/nonebot_plugin_tetris_stats/games/tetrio/rank/snapshot.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/rank/snapshot.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass
+from typing import Literal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from ....i18n import Lang
+from ....utils.exception import NeedCatchError
+from ....utils.metrics import get_metrics
+from ..api.schemas.leaderboards.by import Entry
+from ..models import TETRIOLeagueStats
+
+ListSort = Literal['league', 'pps', 'apm', 'adpm', 'apl', 'adpl']
+
+
+class LeagueSnapshotNotFoundError(NeedCatchError):
+    """No persisted TETR.IO league snapshot is available."""
+
+
+@dataclass(frozen=True)
+class LeagueListQuery:
+    sort: ListSort = 'league'
+    max_tr: float | None = None
+    min_tr: float | None = None
+    limit: int = 25
+    country: str | None = None
+
+
+def _metric(entry: Entry, sort: ListSort) -> float | int | None:
+    league = entry.league
+    if sort == 'league':
+        return round(league.tr, 2)
+    if sort in ('apl', 'adpl') and not league.pps:
+        return None
+
+    metrics = get_metrics(pps=league.pps, apm=league.apm, vs=league.vs)
+    return {
+        'pps': metrics.pps,
+        'apm': metrics.apm,
+        'adpm': metrics.adpm,
+        'apl': metrics.apl,
+        'adpl': metrics.adpl,
+    }[sort]
+
+
+async def query_league_list(session: AsyncSession, query: LeagueListQuery) -> list[Entry]:
+    """Read and rank players from the latest persisted league snapshot."""
+    latest = (
+        await session.scalars(
+            select(TETRIOLeagueStats)
+            .order_by(TETRIOLeagueStats.id.desc())
+            .limit(1)
+            .options(selectinload(TETRIOLeagueStats.raw))
+        )
+    ).one_or_none()
+    if latest is None or not latest.raw:
+        raise LeagueSnapshotNotFoundError(Lang.list.no_snapshot())
+
+    country = query.country.upper() if query.country is not None else None
+    entries = [
+        entry
+        for historical in sorted(latest.raw, key=lambda item: item.id)
+        for entry in historical.data.data.entries
+        if isinstance(entry, Entry)
+        and (query.max_tr is None or entry.league.tr <= query.max_tr)
+        and (query.min_tr is None or entry.league.tr >= query.min_tr)
+        and (country is None or entry.country == country)
+    ]
+
+    # League order is the deterministic tie-breaker for every metric.
+    entries.sort(key=lambda entry: entry.league.tr, reverse=True)
+    if query.sort == 'league':
+        if query.min_tr is not None:
+            return entries[-query.limit :] if query.limit else []
+        return entries[: query.limit]
+
+    ranked_entries: list[tuple[float | int, Entry]] = []
+    for entry in entries:
+        metric = _metric(entry, query.sort)
+        if metric is not None:
+            ranked_entries.append((metric, entry))
+    ranked_entries.sort(key=lambda ranked_entry: ranked_entry[0], reverse=True)
+    return [entry for _, entry in ranked_entries[: query.limit]]
+
+
+__all__ = [
+    'LeagueListQuery',
+    'LeagueSnapshotNotFoundError',
+    'ListSort',
+    'query_league_list',
+]

--- a/nonebot_plugin_tetris_stats/games/tetrio/rank/snapshot.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/rank/snapshot.py
@@ -21,23 +21,6 @@ class LeagueListQuery:
     country: str | None = None
 
 
-def _metric(entry: Entry, sort: ListSort) -> float | int | None:
-    league = entry.league
-    if sort == 'league':
-        return round(league.tr, 2)
-    if sort in ('apl', 'adpl') and not league.pps:
-        return None
-
-    metrics = get_metrics(pps=league.pps, apm=league.apm, vs=league.vs)
-    return {
-        'pps': metrics.pps,
-        'apm': metrics.apm,
-        'adpm': metrics.adpm,
-        'apl': metrics.apl,
-        'adpl': metrics.adpl,
-    }[sort]
-
-
 async def query_league_list(session: AsyncSession, query: LeagueListQuery) -> list[Entry]:
     """Read and rank players from the latest persisted league snapshot."""
     latest = (
@@ -64,21 +47,26 @@ async def query_league_list(session: AsyncSession, query: LeagueListQuery) -> li
 
     # League order is the deterministic tie-breaker for every metric.
     entries.sort(key=lambda entry: entry.league.tr, reverse=True)
-    if query.sort == 'league':
+    sort = query.sort
+    if sort == 'league':
         if query.min_tr is not None:
             return entries[-query.limit :] if query.limit else []
         return entries[: query.limit]
 
     ranked_entries: list[tuple[float | int, Entry]] = []
     for entry in entries:
-        metric = _metric(entry, query.sort)
-        if metric is not None:
-            ranked_entries.append((metric, entry))
+        league = entry.league
+        if sort in ('apl', 'adpl') and not league.pps:
+            continue
+
+        metrics = get_metrics(pps=league.pps, apm=league.apm, vs=league.vs)
+        metric = {
+            'pps': metrics.pps,
+            'apm': metrics.apm,
+            'adpm': metrics.adpm,
+            'apl': metrics.apl,
+            'adpl': metrics.adpl,
+        }[sort]
+        ranked_entries.append((metric, entry))
     ranked_entries.sort(key=lambda ranked_entry: ranked_entry[0], reverse=True)
     return [entry for _, entry in ranked_entries[: query.limit]]
-
-
-__all__ = [
-    'LeagueListQuery',
-    'query_league_list',
-]

--- a/nonebot_plugin_tetris_stats/games/tetrio/rank/snapshot.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/rank/snapshot.py
@@ -5,9 +5,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from ....i18n import Lang
-from ....utils.exception import LeagueSnapshotNotFoundError
 from ....utils.metrics import get_metrics
 from ..api.schemas.leaderboards.by import Entry
+from ..exception import LeagueSnapshotNotFoundError
 from ..models import TETRIOLeagueStats
 from ..typedefs import ListSort
 

--- a/nonebot_plugin_tetris_stats/games/tetrio/rank/snapshot.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/rank/snapshot.py
@@ -1,21 +1,15 @@
 from dataclasses import dataclass
-from typing import Literal
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from ....i18n import Lang
-from ....utils.exception import NeedCatchError
+from ....utils.exception import LeagueSnapshotNotFoundError
 from ....utils.metrics import get_metrics
 from ..api.schemas.leaderboards.by import Entry
 from ..models import TETRIOLeagueStats
-
-ListSort = Literal['league', 'pps', 'apm', 'adpm', 'apl', 'adpl']
-
-
-class LeagueSnapshotNotFoundError(NeedCatchError):
-    """No persisted TETR.IO league snapshot is available."""
+from ..typedefs import ListSort
 
 
 @dataclass(frozen=True)
@@ -86,7 +80,5 @@ async def query_league_list(session: AsyncSession, query: LeagueListQuery) -> li
 
 __all__ = [
     'LeagueListQuery',
-    'LeagueSnapshotNotFoundError',
-    'ListSort',
     'query_league_list',
 ]

--- a/nonebot_plugin_tetris_stats/games/tetrio/typedefs.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/typedefs.py
@@ -1,3 +1,4 @@
 from typing import Literal
 
+ListSort = Literal['league', 'pps', 'apm', 'adpm', 'apl', 'adpl']
 Template = Literal['v1', 'v2']

--- a/nonebot_plugin_tetris_stats/i18n/.lang.schema.json
+++ b/nonebot_plugin_tetris_stats/i18n/.lang.schema.json
@@ -80,6 +80,255 @@
           "type": "string"
         }
       }
+    },
+    "bind": {
+      "title": "Bind",
+      "description": "Scope 'bind' of lang item",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "not_found": {
+          "title": "not_found",
+          "description": "value of lang item type 'not_found'",
+          "type": "string"
+        },
+        "no_account": {
+          "title": "no_account",
+          "description": "value of lang item type 'no_account'",
+          "type": "string"
+        },
+        "confirm_unbind": {
+          "title": "confirm_unbind",
+          "description": "value of lang item type 'confirm_unbind'",
+          "type": "string"
+        },
+        "config_success": {
+          "title": "config_success",
+          "description": "value of lang item type 'config_success'",
+          "type": "string"
+        },
+        "verify_already": {
+          "title": "verify_already",
+          "description": "value of lang item type 'verify_already'",
+          "type": "string"
+        },
+        "verify_failed": {
+          "title": "verify_failed",
+          "description": "value of lang item type 'verify_failed'",
+          "type": "string"
+        },
+        "only_discord": {
+          "title": "only_discord",
+          "description": "value of lang item type 'only_discord'",
+          "type": "string"
+        }
+      }
+    },
+    "record": {
+      "title": "Record",
+      "description": "Scope 'record' of lang item",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "not_found": {
+          "title": "not_found",
+          "description": "value of lang item type 'not_found'",
+          "type": "string"
+        },
+        "blitz": {
+          "title": "blitz",
+          "description": "value of lang item type 'blitz'",
+          "type": "string"
+        },
+        "sprint": {
+          "title": "sprint",
+          "description": "value of lang item type 'sprint'",
+          "type": "string"
+        }
+      }
+    },
+    "list": {
+      "title": "List",
+      "description": "Scope 'list' of lang item",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "no_snapshot": {
+          "title": "no_snapshot",
+          "description": "value of lang item type 'no_snapshot'",
+          "type": "string"
+        }
+      }
+    },
+    "stats": {
+      "title": "Stats",
+      "description": "Scope 'stats' of lang item",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "user_info": {
+          "title": "user_info",
+          "description": "value of lang item type 'user_info'",
+          "type": "string"
+        },
+        "no_rank": {
+          "title": "no_rank",
+          "description": "value of lang item type 'no_rank'",
+          "type": "string"
+        },
+        "rank_info": {
+          "title": "rank_info",
+          "description": "value of lang item type 'rank_info'",
+          "type": "string"
+        },
+        "no_game": {
+          "title": "no_game",
+          "description": "value of lang item type 'no_game'",
+          "type": "string"
+        },
+        "recent_games": {
+          "title": "recent_games",
+          "description": "value of lang item type 'recent_games'",
+          "type": "string"
+        },
+        "daily_stats": {
+          "title": "daily_stats",
+          "description": "value of lang item type 'daily_stats'",
+          "type": "string"
+        },
+        "no_daily": {
+          "title": "no_daily",
+          "description": "value of lang item type 'no_daily'",
+          "type": "string"
+        },
+        "history_stats": {
+          "title": "history_stats",
+          "description": "value of lang item type 'history_stats'",
+          "type": "string"
+        },
+        "no_history": {
+          "title": "no_history",
+          "description": "value of lang item type 'no_history'",
+          "type": "string"
+        },
+        "lpm": {
+          "title": "lpm",
+          "description": "value of lang item type 'lpm'",
+          "type": "string"
+        },
+        "apm": {
+          "title": "apm",
+          "description": "value of lang item type 'apm'",
+          "type": "string"
+        },
+        "adpm": {
+          "title": "adpm",
+          "description": "value of lang item type 'adpm'",
+          "type": "string"
+        },
+        "sprint_pb": {
+          "title": "sprint_pb",
+          "description": "value of lang item type 'sprint_pb'",
+          "type": "string"
+        },
+        "marathon_pb": {
+          "title": "marathon_pb",
+          "description": "value of lang item type 'marathon_pb'",
+          "type": "string"
+        },
+        "challenge_pb": {
+          "title": "challenge_pb",
+          "description": "value of lang item type 'challenge_pb'",
+          "type": "string"
+        }
+      }
+    },
+    "template_ui": {
+      "title": "Template_ui",
+      "description": "Scope 'template_ui' of lang item",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "invalid_tag": {
+          "title": "invalid_tag",
+          "description": "value of lang item type 'invalid_tag'",
+          "type": "string"
+        },
+        "update_success": {
+          "title": "update_success",
+          "description": "value of lang item type 'update_success'",
+          "type": "string"
+        },
+        "update_failed": {
+          "title": "update_failed",
+          "description": "value of lang item type 'update_failed'",
+          "type": "string"
+        }
+      }
+    },
+    "help": {
+      "title": "Help",
+      "description": "Scope 'help' of lang item",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "usage": {
+          "title": "usage",
+          "description": "value of lang item type 'usage'",
+          "type": "string"
+        }
+      }
+    },
+    "prompt": {
+      "title": "Prompt",
+      "description": "Scope 'prompt' of lang item",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "io_check": {
+          "title": "io_check",
+          "description": "value of lang item type 'io_check'",
+          "type": "string"
+        },
+        "io_bind": {
+          "title": "io_bind",
+          "description": "value of lang item type 'io_bind'",
+          "type": "string"
+        },
+        "top_check": {
+          "title": "top_check",
+          "description": "value of lang item type 'top_check'",
+          "type": "string"
+        },
+        "top_bind": {
+          "title": "top_bind",
+          "description": "value of lang item type 'top_bind'",
+          "type": "string"
+        },
+        "tos_check": {
+          "title": "tos_check",
+          "description": "value of lang item type 'tos_check'",
+          "type": "string"
+        },
+        "tos_bind": {
+          "title": "tos_bind",
+          "description": "value of lang item type 'tos_bind'",
+          "type": "string"
+        }
+      }
+    },
+    "retry": {
+      "title": "Retry",
+      "description": "Scope 'retry' of lang item",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "message": {
+          "title": "message",
+          "description": "value of lang item type 'message'",
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/nonebot_plugin_tetris_stats/i18n/.template.json
+++ b/nonebot_plugin_tetris_stats/i18n/.template.json
@@ -30,6 +30,10 @@
       "types": ["not_found", "blitz", "sprint"]
     },
     {
+      "scope": "list",
+      "types": ["no_snapshot"]
+    },
+    {
       "scope": "stats",
       "types": [
         "user_info",

--- a/nonebot_plugin_tetris_stats/i18n/en-US.json
+++ b/nonebot_plugin_tetris_stats/i18n/en-US.json
@@ -30,6 +30,9 @@
     "blitz": "Blitz",
     "sprint": "40L"
   },
+  "list": {
+    "no_snapshot": "No TETR.IO league ranking snapshot is available yet. Please try again later."
+  },
   "stats": {
     "user_info": "User {name} ({id})",
     "no_rank": "No rank statistics available",

--- a/nonebot_plugin_tetris_stats/i18n/model.py
+++ b/nonebot_plugin_tetris_stats/i18n/model.py
@@ -47,6 +47,10 @@ class Record:
     sprint: LangItem = LangItem('record', 'sprint')
 
 
+class List:
+    no_snapshot: LangItem = LangItem('list', 'no_snapshot')
+
+
 class Stats:
     user_info: LangItem = LangItem('stats', 'user_info')
     no_rank: LangItem = LangItem('stats', 'no_rank')
@@ -94,6 +98,7 @@ class Lang(LangModel):
     template = Template
     bind = Bind
     record = Record
+    list = List
     stats = Stats
     template_ui = TemplateUi
     help = Help

--- a/nonebot_plugin_tetris_stats/i18n/zh-CN.json
+++ b/nonebot_plugin_tetris_stats/i18n/zh-CN.json
@@ -28,6 +28,9 @@
     "blitz": "Blitz",
     "sprint": "40L"
   },
+  "list": {
+    "no_snapshot": "暂无 TETR.IO 段位排行榜快照，请稍后再试"
+  },
   "stats": {
     "user_info": "用户 {name} ({id})",
     "no_rank": "暂无段位统计数据",

--- a/nonebot_plugin_tetris_stats/utils/exception.py
+++ b/nonebot_plugin_tetris_stats/utils/exception.py
@@ -36,6 +36,10 @@ class RecordNotFoundError(NeedCatchError):
     """找不到用户的某种记录"""
 
 
+class LeagueSnapshotNotFoundError(NeedCatchError):
+    """No persisted TETR.IO league snapshot is available."""
+
+
 class FallbackError(NeedCatchError):
     """需要回滚至更通用的方法"""
 

--- a/nonebot_plugin_tetris_stats/utils/exception.py
+++ b/nonebot_plugin_tetris_stats/utils/exception.py
@@ -36,10 +36,6 @@ class RecordNotFoundError(NeedCatchError):
     """找不到用户的某种记录"""
 
 
-class LeagueSnapshotNotFoundError(NeedCatchError):
-    """No persisted TETR.IO league snapshot is available."""
-
-
 class FallbackError(NeedCatchError):
     """需要回滚至更通用的方法"""
 

--- a/tests/tetrio/test_list.py
+++ b/tests/tetrio/test_list.py
@@ -1,0 +1,307 @@
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+if TYPE_CHECKING:
+    from nonebot_plugin_tetris_stats.games.tetrio.api.schemas.leaderboards.by import Entry, InvalidEntry
+    from nonebot_plugin_tetris_stats.games.tetrio.models import TETRIOLeagueStats
+    from nonebot_plugin_tetris_stats.games.tetrio.rank.snapshot import ListSort
+
+
+UTC = timezone.utc
+
+
+@dataclass(frozen=True)
+class MetricCase:
+    sort: 'ListSort'
+    pps: float
+    apm: float
+    vs: float
+    expected_first: str
+
+
+@pytest.fixture
+async def league_sessionmaker() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    from nonebot_plugin_tetris_stats.games.tetrio.models import (  # noqa: PLC0415
+        TETRIOLeagueHistorical,
+        TETRIOLeagueStats,
+    )
+
+    engine = create_async_engine('sqlite+aiosqlite:///:memory:')
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: TETRIOLeagueStats.metadata.create_all(
+                sync_conn,
+                tables=[TETRIOLeagueStats.__table__, TETRIOLeagueHistorical.__table__],
+            )
+        )
+    yield async_sessionmaker(engine, expire_on_commit=False)
+    await engine.dispose()
+
+
+def make_entry(
+    user_id: str,
+    *,
+    tr: float,
+    pps: float = 2.0,
+    apm: float = 40.0,
+    vs: float = 80.0,
+) -> 'Entry':
+    from nonebot_plugin_tetris_stats.games.tetrio.api.schemas.base import ArCounts, P  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.games.tetrio.api.schemas.leaderboards.by import (  # noqa: PLC0415
+        Entry,
+        League,
+    )
+
+    return Entry(
+        _id=user_id,
+        username=user_id,
+        role='user',
+        ts=None,
+        xp=0.0,
+        country='US',
+        supporter=None,
+        gamesplayed=10,
+        gameswon=6,
+        gametime=1.0,
+        ar=0,
+        ar_counts=ArCounts(),
+        p=P(pri=tr, sec=0.0, ter=0.0),
+        league=League(
+            gamesplayed=10,
+            gameswon=6,
+            tr=tr,
+            gxe=0.5,
+            rank='s',
+            bestrank='s',
+            glicko=1500.0,
+            rd=50.0,
+            decaying=False,
+            pps=pps,
+            apm=apm,
+            vs=vs,
+        ),
+    )
+
+
+def make_snapshot(entries: Sequence['Entry'], *, when: datetime, request_id: int) -> 'TETRIOLeagueStats':
+    from nonebot_plugin_tetris_stats.games.tetrio.api.schemas.base import Cache  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.games.tetrio.api.schemas.leaderboards.by import (  # noqa: PLC0415
+        BySuccessModel,
+        Data,
+    )
+    from nonebot_plugin_tetris_stats.games.tetrio.models import (  # noqa: PLC0415
+        TETRIOLeagueHistorical,
+        TETRIOLeagueStats,
+    )
+
+    persisted_entries: list[Entry | InvalidEntry] = []
+    persisted_entries.extend(entries)
+    stats = TETRIOLeagueStats(raw=[], fields=[], update_time=when)
+    historical = TETRIOLeagueHistorical(
+        request_id=UUID(int=request_id),
+        data=BySuccessModel(
+            success=True,
+            cache=Cache(status='cached', cached_at=when, cached_until=when + timedelta(minutes=5)),
+            data=Data(entries=persisted_entries),
+        ),
+        update_time=when,
+        stats=stats,
+    )
+    stats.raw = [historical]
+    return stats
+
+
+@pytest.mark.parametrize('sort', ['league', 'pps', 'apm', 'adpm', 'apl', 'adpl'])
+def test_list_accepts_all_sort_values(sort: str) -> None:
+    from nonebot_plugin_tetris_stats.games import command  # noqa: PLC0415
+
+    result = command.parse(f'tstats TETR.IO list --sort {sort}')
+
+    assert result.matched  # noqa: S101
+    assert result.all_matched_args['sort'] == sort  # noqa: S101
+
+
+def test_list_defaults_to_league_sort() -> None:
+    from nonebot_plugin_tetris_stats.games import command  # noqa: PLC0415
+
+    result = command.parse('tstats TETR.IO list')
+
+    assert result.matched  # noqa: S101
+    assert 'sort' not in result.all_matched_args  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_league_list_defaults_to_descending_league_order(
+    league_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    from nonebot_plugin_tetris_stats.games.tetrio.rank.snapshot import (  # noqa: PLC0415
+        LeagueListQuery,
+        query_league_list,
+    )
+
+    async with league_sessionmaker() as session:
+        session.add(
+            make_snapshot(
+                [make_entry('lower', tr=12000), make_entry('higher', tr=18000)],
+                when=datetime(2026, 8, 30, tzinfo=UTC),
+                request_id=1,
+            )
+        )
+        await session.commit()
+
+    async with league_sessionmaker() as session:
+        entries = await query_league_list(session, LeagueListQuery())
+
+    assert [entry.id for entry in entries] == ['higher', 'lower']  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_league_list_min_tr_returns_window_closest_to_lower_bound(
+    league_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    from nonebot_plugin_tetris_stats.games.tetrio.rank.snapshot import (  # noqa: PLC0415
+        LeagueListQuery,
+        query_league_list,
+    )
+
+    async with league_sessionmaker() as session:
+        session.add(
+            make_snapshot(
+                [
+                    make_entry('highest', tr=18000),
+                    make_entry('nearest', tr=11000),
+                    make_entry('middle', tr=15000),
+                    make_entry('next-nearest', tr=12000),
+                ],
+                when=datetime(2026, 8, 30, tzinfo=UTC),
+                request_id=2,
+            )
+        )
+        await session.commit()
+
+    async with league_sessionmaker() as session:
+        entries = await query_league_list(session, LeagueListQuery(min_tr=10000, limit=2))
+
+    assert [entry.id for entry in entries] == ['next-nearest', 'nearest']  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    'case',
+    [
+        MetricCase('league', 2.0, 40.0, 80.0, 'league-first'),
+        MetricCase('pps', 3.0, 40.0, 80.0, 'metric-first'),
+        MetricCase('apm', 2.0, 50.0, 80.0, 'metric-first'),
+        MetricCase('adpm', 2.0, 40.0, 90.0, 'metric-first'),
+        MetricCase('apl', 1.0, 30.0, 80.0, 'metric-first'),
+        MetricCase('adpl', 1.0, 40.0, 60.0, 'metric-first'),
+    ],
+)
+@pytest.mark.asyncio
+async def test_league_list_sorts_by_selected_metric(
+    league_sessionmaker: async_sessionmaker[AsyncSession],
+    case: MetricCase,
+) -> None:
+    from nonebot_plugin_tetris_stats.games.tetrio.rank.snapshot import (  # noqa: PLC0415
+        LeagueListQuery,
+        query_league_list,
+    )
+
+    async with league_sessionmaker() as session:
+        session.add(
+            make_snapshot(
+                [
+                    make_entry('league-first', tr=18000, pps=2.0, apm=40.0, vs=80.0),
+                    make_entry('metric-first', tr=12000, pps=case.pps, apm=case.apm, vs=case.vs),
+                ],
+                when=datetime(2026, 8, 30, tzinfo=UTC),
+                request_id=3,
+            )
+        )
+        await session.commit()
+
+    async with league_sessionmaker() as session:
+        entries = await query_league_list(session, LeagueListQuery(sort=case.sort))
+
+    assert entries[0].id == case.expected_first  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_league_list_uses_visible_metric_precision_before_tr_tiebreak(
+    league_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    from nonebot_plugin_tetris_stats.games.tetrio.rank.snapshot import (  # noqa: PLC0415
+        LeagueListQuery,
+        query_league_list,
+    )
+
+    async with league_sessionmaker() as session:
+        session.add(
+            make_snapshot(
+                [
+                    make_entry('higher-tr', tr=18000, vs=80.0),
+                    make_entry('higher-raw-adpm', tr=12000, vs=80.006),
+                ],
+                when=datetime(2026, 8, 30, tzinfo=UTC),
+                request_id=4,
+            )
+        )
+        await session.commit()
+
+    async with league_sessionmaker() as session:
+        entries = await query_league_list(session, LeagueListQuery(sort='adpm'))
+
+    assert [entry.id for entry in entries] == ['higher-tr', 'higher-raw-adpm']  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_league_list_reads_only_the_latest_persisted_snapshot(
+    league_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    from nonebot_plugin_tetris_stats.games.tetrio.rank.snapshot import (  # noqa: PLC0415
+        LeagueListQuery,
+        query_league_list,
+    )
+
+    async with league_sessionmaker() as session:
+        session.add(
+            make_snapshot(
+                [make_entry('stale', tr=20000)],
+                when=datetime(2026, 8, 29, tzinfo=UTC),
+                request_id=5,
+            )
+        )
+        await session.flush()
+        session.add(
+            make_snapshot(
+                [make_entry('fresh', tr=10000)],
+                when=datetime(2026, 8, 30, tzinfo=UTC),
+                request_id=6,
+            )
+        )
+        await session.commit()
+
+    async with league_sessionmaker() as session:
+        entries = await query_league_list(session, LeagueListQuery())
+
+    assert [entry.id for entry in entries] == ['fresh']  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_league_list_reports_missing_snapshot(
+    league_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    from nonebot_plugin_tetris_stats.games.tetrio.rank.snapshot import (  # noqa: PLC0415
+        LeagueListQuery,
+        LeagueSnapshotNotFoundError,
+        query_league_list,
+    )
+
+    async with league_sessionmaker() as session:
+        with pytest.raises(LeagueSnapshotNotFoundError):
+            await query_league_list(session, LeagueListQuery())

--- a/tests/tetrio/test_list.py
+++ b/tests/tetrio/test_list.py
@@ -1,16 +1,20 @@
 from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
 from uuid import UUID
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 if TYPE_CHECKING:
+    from nonebot_plugin_uninfo.model import Session as UninfoSession
+
     from nonebot_plugin_tetris_stats.games.tetrio.api.schemas.leaderboards.by import Entry, InvalidEntry
     from nonebot_plugin_tetris_stats.games.tetrio.models import TETRIOLeagueStats
-    from nonebot_plugin_tetris_stats.games.tetrio.rank.snapshot import ListSort
+    from nonebot_plugin_tetris_stats.games.tetrio.rank.snapshot import LeagueListQuery, ListSort
 
 
 UTC = timezone.utc
@@ -134,6 +138,67 @@ def test_list_defaults_to_league_sort() -> None:
 
     assert result.matched  # noqa: S101
     assert 'sort' not in result.all_matched_args  # noqa: S101
+
+
+@pytest.mark.parametrize('sort', [None, 'league', 'pps'])
+@pytest.mark.asyncio
+async def test_list_uses_live_api_only_for_league_sort(
+    monkeypatch: pytest.MonkeyPatch,
+    sort: str | None,
+) -> None:
+    from nonebot_plugin_alconna.uniseg import UniMessage  # noqa: PLC0415
+
+    from nonebot_plugin_tetris_stats.games import alc  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.games.tetrio import list as list_module  # noqa: PLC0415
+
+    api_calls: list[object] = []
+    snapshot_sorts: list[str] = []
+
+    @asynccontextmanager
+    async def fake_trigger(**_: object) -> AsyncIterator[None]:
+        yield
+
+    @asynccontextmanager
+    async def fake_get_session() -> AsyncIterator[object]:
+        yield object()
+
+    async def fake_get_session_persist_id(_: object) -> int:
+        return 1
+
+    async def fake_by(*args: object, **kwargs: object) -> SimpleNamespace:
+        api_calls.append((args, kwargs))
+        return SimpleNamespace(data=SimpleNamespace(entries=[]))
+
+    async def fake_query_league_list(_: object, query: 'LeagueListQuery') -> list[object]:
+        snapshot_sorts.append(query.sort)
+        return []
+
+    async def fake_render_image(*_: object, **__: object) -> bytes:
+        return b''
+
+    async def capture_finish(*_: object, **__: object) -> None:
+        return None
+
+    monkeypatch.setattr(list_module, 'trigger', fake_trigger)
+    monkeypatch.setattr(list_module, 'get_session', fake_get_session)
+    monkeypatch.setattr(list_module, 'get_session_persist_id', fake_get_session_persist_id)
+    monkeypatch.setattr(list_module, 'by', fake_by)
+    monkeypatch.setattr(list_module, 'query_league_list', fake_query_league_list)
+    monkeypatch.setattr(list_module, 'render_image', fake_render_image)
+    monkeypatch.setattr(UniMessage, 'finish', capture_finish)
+
+    list_handler = next(handler.call for handler in alc.handlers if handler.call.__module__ == list_module.__name__)
+    await list_handler(
+        event_session=cast('UninfoSession', SimpleNamespace(scope='qq')),
+        sort=sort,
+    )
+
+    if sort in (None, 'league'):
+        assert len(api_calls) == 1  # noqa: S101
+        assert snapshot_sorts == []  # noqa: S101
+    else:
+        assert api_calls == []  # noqa: S101
+        assert snapshot_sorts == [sort]  # noqa: S101
 
 
 @pytest.mark.asyncio

--- a/tests/tetrio/test_list.py
+++ b/tests/tetrio/test_list.py
@@ -362,11 +362,11 @@ async def test_league_list_reads_only_the_latest_persisted_snapshot(
 async def test_league_list_reports_missing_snapshot(
     league_sessionmaker: async_sessionmaker[AsyncSession],
 ) -> None:
+    from nonebot_plugin_tetris_stats.games.tetrio.exception import LeagueSnapshotNotFoundError  # noqa: PLC0415
     from nonebot_plugin_tetris_stats.games.tetrio.rank.snapshot import (  # noqa: PLC0415
         LeagueListQuery,
         query_league_list,
     )
-    from nonebot_plugin_tetris_stats.utils.exception import LeagueSnapshotNotFoundError  # noqa: PLC0415
 
     async with league_sessionmaker() as session:
         with pytest.raises(LeagueSnapshotNotFoundError):

--- a/tests/tetrio/test_list.py
+++ b/tests/tetrio/test_list.py
@@ -14,7 +14,8 @@ if TYPE_CHECKING:
 
     from nonebot_plugin_tetris_stats.games.tetrio.api.schemas.leaderboards.by import Entry, InvalidEntry
     from nonebot_plugin_tetris_stats.games.tetrio.models import TETRIOLeagueStats
-    from nonebot_plugin_tetris_stats.games.tetrio.rank.snapshot import LeagueListQuery, ListSort
+    from nonebot_plugin_tetris_stats.games.tetrio.rank.snapshot import LeagueListQuery
+    from nonebot_plugin_tetris_stats.games.tetrio.typedefs import ListSort
 
 
 UTC = timezone.utc
@@ -363,9 +364,9 @@ async def test_league_list_reports_missing_snapshot(
 ) -> None:
     from nonebot_plugin_tetris_stats.games.tetrio.rank.snapshot import (  # noqa: PLC0415
         LeagueListQuery,
-        LeagueSnapshotNotFoundError,
         query_league_list,
     )
+    from nonebot_plugin_tetris_stats.utils.exception import LeagueSnapshotNotFoundError  # noqa: PLC0415
 
     async with league_sessionmaker() as session:
         with pytest.raises(LeagueSnapshotNotFoundError):


### PR DESCRIPTION
## 修改

- 为 `TETR.IO list` 增加 `--sort league|pps|apm|adpm|apl|adpl`
- 从 rank 持久化的最新快照读取数据，不发起 live leaderboard 请求
- 复用 `utils.metrics` 作为 ADPM/APL/ADPL 唯一公式 owner，每项只计算一次且无 cast
- 保留 TR tie-break、国家/上下界过滤与分页
- 恢复默认 league 模式 `--min-tr` 的旧 before 窗口语义：返回最接近下界的结果
- 无快照时返回本地化错误
- fixture 使用验证构造器，并跨两个 ORM session 验证真实持久化读取

Closes #452

## 验证

- `tests/tetrio/test_list.py`：18 passed
- Ruff：通过
- Mypy：通过
- BasedPyright：0 errors
- `uv build`：sdist + wheel