### PR TITLE
✨ 添加命令权限集成

### DIFF
--- a/nonebot_plugin_tetris_stats/__init__.py
+++ b/nonebot_plugin_tetris_stats/__init__.py
@@ -6,6 +6,7 @@ require_plugins = {
     'nonebot_plugin_apscheduler',
     'nonebot_plugin_localstore',
     'nonebot_plugin_orm',
+    'nonebot_plugin_permission',
     'nonebot_plugin_uninfo',
     'nonebot_plugin_user',
     'nonebot_plugin_waiter',

--- a/nonebot_plugin_tetris_stats/games/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/__init__.py
@@ -8,6 +8,7 @@ from nonebot_plugin_alconna import AlcMatches, Alconna, At, CommandMeta, on_alco
 
 from .. import ns
 from ..i18n import Lang
+from ..permission import command_permission
 from ..utils.exception import NeedCatchError
 from ..utils.help_extension import HelpImageExtension
 from ..utils.help_formatter import StructuredHelpFormatter
@@ -29,6 +30,11 @@ alc = on_alconna(
     use_origin=True,
     extensions=[HelpImageExtension()],
 )
+
+
+def assign(path: str) -> Callable[[T_Handler], T_Handler]:
+    game, command_name = path.split('.', maxsplit=1)
+    return alc.assign(path, parameterless=command_permission(game, command_name))
 
 
 def add_block_handlers(handler: Callable[[T_Handler], T_Handler]) -> None:

--- a/nonebot_plugin_tetris_stats/games/tetrio/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/__init__.py
@@ -1,6 +1,6 @@
 from nonebot_plugin_alconna import Subcommand
 
-from .. import alc
+from .. import alc, assign
 from .. import command as main_command
 from .api import Player
 from .constant import USER_ID, USER_NAME
@@ -29,6 +29,7 @@ main_command.add(command)
 
 __all__ = [
     'alc',
+    'assign',
     'bind',
     'config',
     'list',

--- a/nonebot_plugin_tetris_stats/games/tetrio/bind.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/bind.py
@@ -21,7 +21,7 @@ from ...utils.lang import get_lang
 from ...utils.render import render_image
 from ...utils.render.schemas.base import Avatar, People
 from ...utils.render.schemas.bind import Bind
-from . import alc, command, get_player
+from . import alc, assign, command, get_player
 from .api import Player
 from .constant import GAME_TYPE
 
@@ -49,7 +49,7 @@ alc.shortcut(
 try:
     from nonebot.adapters.discord import MessageCreateEvent
 
-    @alc.assign('TETRIO.bind')
+    @assign('TETRIO.bind')
     async def _(_: MessageCreateEvent, nb_user: User, account: Player, event_session: Uninfo, interface: QryItrface):
         async with trigger(
             session_persist_id=await get_session_persist_id(event_session),
@@ -83,7 +83,7 @@ except ImportError:
     pass
 
 
-@alc.assign('TETRIO.bind')
+@assign('TETRIO.bind')
 async def _(nb_user: User, account: Player, event_session: Uninfo, interface: QryItrface):
     async with trigger(
         session_persist_id=await get_session_persist_id(event_session),

--- a/nonebot_plugin_tetris_stats/games/tetrio/config.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/config.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from ...db import trigger
 from ...i18n import Lang
 from ...utils.duration import parse_duration
-from . import alc, command
+from . import alc, assign, command
 from .constant import GAME_TYPE
 from .models import TETRIOUserConfig
 from .typedefs import Template
@@ -43,7 +43,7 @@ alc.shortcut(
 )
 
 
-@alc.assign('TETRIO.config')
+@assign('TETRIO.config')
 async def _(
     user: User,
     session: async_scoped_session,

--- a/nonebot_plugin_tetris_stats/games/tetrio/list.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/list.py
@@ -10,7 +10,7 @@ from ...utils.lang import get_lang
 from ...utils.metrics import get_metrics
 from ...utils.render import render_image
 from ...utils.render.schemas.v2.tetrio.user.list import Data, List, TetraLeague, User
-from .. import alc
+from .. import assign
 from . import command
 from .api.leaderboards import by
 from .api.schemas.base import P
@@ -36,7 +36,7 @@ command.add(
 )
 
 
-@alc.assign('TETRIO.list')
+@assign('TETRIO.list')
 async def _(
     event_session: Uninfo,
     max_tr: float | None = None,

--- a/nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/query/__init__.py
@@ -18,7 +18,7 @@ from ....i18n import Lang
 from ....utils.duration import parse_duration
 from ....utils.exception import FallbackError
 from ....utils.typedefs import Me
-from ... import add_block_handlers, alc
+from ... import add_block_handlers, alc, assign
 from .. import command, get_player
 from ..api import Player
 from ..constant import GAME_TYPE
@@ -70,7 +70,7 @@ alc.shortcut(
     humanized='An Easter egg!',
 )
 
-add_block_handlers(alc.assign('TETRIO.query'))
+add_block_handlers(assign('TETRIO.query'))
 
 
 async def make_query_result(player: Player, template: Template, compare_delta: timedelta) -> UniMessage:
@@ -84,7 +84,7 @@ async def make_query_result(player: Player, template: Template, compare_delta: t
     return None
 
 
-@alc.assign('TETRIO.query')
+@assign('TETRIO.query')
 async def _(  # noqa: PLR0913, PLR0917
     user: NBUser,
     event: Event,
@@ -126,7 +126,7 @@ async def _(  # noqa: PLR0913, PLR0917
         await (warning + result).finish()
 
 
-@alc.assign('TETRIO.query')
+@assign('TETRIO.query')
 async def _(
     user: NBUser,
     who: Player,

--- a/nonebot_plugin_tetris_stats/games/tetrio/rank/all.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/rank/all.py
@@ -17,7 +17,7 @@ from ....utils.render.schemas.v1.tetrio.rank import ItemData as ItemDataV1
 from ....utils.render.schemas.v2.tetrio.rank import AverageData as AverageDataV2
 from ....utils.render.schemas.v2.tetrio.rank import Data as DataV2
 from ....utils.render.schemas.v2.tetrio.rank import ItemData as ItemDataV2
-from .. import alc
+from .. import assign
 from ..constant import GAME_TYPE
 from ..models import TETRIOLeagueStats
 from ..typedefs import Template
@@ -33,7 +33,7 @@ command.add(
 )
 
 
-@alc.assign('TETRIO.rank.all')
+@assign('TETRIO.rank.all')
 async def _(event_session: Uninfo, template: Template | None = None):
     async with trigger(
         session_persist_id=await get_session_persist_id(event_session),

--- a/nonebot_plugin_tetris_stats/games/tetrio/rank/detail.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/rank/detail.py
@@ -15,7 +15,7 @@ from ....utils.lang import get_lang
 from ....utils.metrics import get_metrics
 from ....utils.render import render_image
 from ....utils.render.schemas.v2.tetrio.rank.detail import Data, SpecialData
-from .. import alc
+from .. import assign
 from ..api.typedefs import ValidRank
 from ..constant import GAME_TYPE
 from ..models import TETRIOLeagueStats
@@ -36,7 +36,7 @@ command.add(
 )
 
 
-@alc.assign('TETRIO.rank.detail')
+@assign('TETRIO.rank.detail')
 async def _(rank: ValidRank, event_session: Uninfo):
     async with trigger(
         session_persist_id=await get_session_persist_id(event_session),

--- a/nonebot_plugin_tetris_stats/games/tetrio/record/blitz.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/record/blitz.py
@@ -23,7 +23,7 @@ from ....utils.render.schemas.base import Avatar
 from ....utils.render.schemas.v2.tetrio.record.base import Finesse, Max, Mini, Tspins, User
 from ....utils.render.schemas.v2.tetrio.record.blitz import Record, Statistic
 from ....utils.typedefs import Me
-from .. import alc
+from .. import alc, assign
 from ..api.player import Player
 from ..constant import GAME_TYPE
 from . import command
@@ -37,7 +37,7 @@ alc.shortcut(
 )
 
 
-@alc.assign('TETRIO.record.blitz')
+@assign('TETRIO.record.blitz')
 async def _(
     event: Event,
     matcher: Matcher,
@@ -65,7 +65,7 @@ async def _(
         ).finish()
 
 
-@alc.assign('TETRIO.record.blitz')
+@assign('TETRIO.record.blitz')
 async def _(who: Player, event_session: Uninfo):
     async with trigger(
         session_persist_id=await get_session_persist_id(event_session),

--- a/nonebot_plugin_tetris_stats/games/tetrio/record/sprint.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/record/sprint.py
@@ -23,7 +23,7 @@ from ....utils.render.schemas.base import Avatar
 from ....utils.render.schemas.v2.tetrio.record.base import Finesse, Max, Mini, Statistic, Tspins, User
 from ....utils.render.schemas.v2.tetrio.record.sprint import Record
 from ....utils.typedefs import Me
-from .. import alc
+from .. import alc, assign
 from ..api.player import Player
 from ..constant import GAME_TYPE
 from . import command
@@ -37,7 +37,7 @@ alc.shortcut(
 )
 
 
-@alc.assign('TETRIO.record.sprint')
+@assign('TETRIO.record.sprint')
 async def _(
     event: Event,
     matcher: Matcher,
@@ -65,7 +65,7 @@ async def _(
         ).finish()
 
 
-@alc.assign('TETRIO.record.sprint')
+@assign('TETRIO.record.sprint')
 async def _(who: Player, event_session: Uninfo):
     async with trigger(
         session_persist_id=await get_session_persist_id(event_session),

--- a/nonebot_plugin_tetris_stats/games/tetrio/unbind.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/unbind.py
@@ -20,7 +20,7 @@ from ...utils.lang import get_lang
 from ...utils.render import render_image
 from ...utils.render.schemas.base import Avatar, People
 from ...utils.render.schemas.bind import Bind
-from . import alc, command
+from . import alc, assign, command
 from .api import Player
 from .constant import GAME_TYPE
 
@@ -33,7 +33,7 @@ alc.shortcut(
 )
 
 
-@alc.assign('TETRIO.unbind')
+@assign('TETRIO.unbind')
 async def _(nb_user: User, event_session: Uninfo, interface: QryItrface):
     async with (
         trigger(

--- a/nonebot_plugin_tetris_stats/games/tetrio/verify.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/verify.py
@@ -20,7 +20,7 @@ from ...utils.lang import get_lang
 from ...utils.render import render_image
 from ...utils.render.schemas.base import Avatar, People
 from ...utils.render.schemas.bind import Bind
-from . import alc, command
+from . import alc, assign, command
 from .api import Player
 from .constant import GAME_TYPE
 
@@ -35,7 +35,7 @@ alc.shortcut(
 try:
     from nonebot.adapters.discord import MessageCreateEvent
 
-    @alc.assign('TETRIO.verify')
+    @assign('TETRIO.verify')
     async def _(_: MessageCreateEvent, nb_user: User, event_session: Uninfo, interface: QryItrface):
         async with (
             trigger(
@@ -100,7 +100,7 @@ except ImportError:
     pass
 
 
-@alc.assign('TETRIO.verify')
+@assign('TETRIO.verify')
 async def _(event_session: Uninfo):
     async with trigger(
         session_persist_id=await get_session_persist_id(event_session),

--- a/nonebot_plugin_tetris_stats/games/top/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/top/__init__.py
@@ -3,7 +3,7 @@ from nonebot_plugin_alconna import Args, At, Option, Subcommand
 
 from ...utils.duration import parse_duration
 from ...utils.typedefs import Me
-from .. import add_block_handlers, alc, command
+from .. import add_block_handlers, alc, assign, command
 from .api import Player
 from .constant import USER_NAME
 
@@ -86,6 +86,6 @@ alc.shortcut(
     humanized='top配置',
 )
 
-add_block_handlers(alc.assign('TOP.query'))
+add_block_handlers(assign('TOP.query'))
 
 from . import bind, config, query, unbind  # noqa: E402, F401

--- a/nonebot_plugin_tetris_stats/games/top/bind.py
+++ b/nonebot_plugin_tetris_stats/games/top/bind.py
@@ -15,12 +15,12 @@ from ...utils.lang import get_lang
 from ...utils.render import render_image
 from ...utils.render.schemas.base import People
 from ...utils.render.schemas.bind import Bind
-from . import alc
+from . import assign
 from .api import Player
 from .constant import GAME_TYPE
 
 
-@alc.assign('TOP.bind')
+@assign('TOP.bind')
 async def _(nb_user: User, account: Player, event_session: Uninfo, interface: QryItrface):
     async with trigger(
         session_persist_id=await get_session_persist_id(event_session),

--- a/nonebot_plugin_tetris_stats/games/top/config.py
+++ b/nonebot_plugin_tetris_stats/games/top/config.py
@@ -9,12 +9,12 @@ from sqlalchemy import select
 
 from ...db import trigger
 from ...i18n import Lang
-from . import alc
+from . import assign
 from .constant import GAME_TYPE
 from .models import TOPUserConfig
 
 
-@alc.assign('TOP.config')
+@assign('TOP.config')
 async def _(user: User, session: async_scoped_session, event_session: Uninfo, compare: timedelta):
     async with trigger(
         session_persist_id=await get_session_persist_id(event_session),

--- a/nonebot_plugin_tetris_stats/games/top/query.py
+++ b/nonebot_plugin_tetris_stats/games/top/query.py
@@ -23,7 +23,7 @@ from ...utils.render.schemas.v1.top.info import Data as InfoData
 from ...utils.render.schemas.v1.top.info import Info
 from ...utils.timezone import ensure_utc_datetime
 from ...utils.typedefs import Me
-from . import alc
+from . import assign
 from .api import Player
 from .api.models import TOPHistoricalData
 from .api.schemas.user_profile import Data, UserProfile
@@ -79,7 +79,7 @@ def compare_metrics(
     return Trending.compare(compare.lpm, current.lpm), Trending.compare(compare.apm, current.apm)
 
 
-@alc.assign('TOP.query')
+@assign('TOP.query')
 async def _(  # noqa: PLR0913, PLR0917
     user: NBUser,
     event: Event,
@@ -117,7 +117,7 @@ async def _(  # noqa: PLR0913, PLR0917
         await (warning + result).finish()
 
 
-@alc.assign('TOP.query')
+@assign('TOP.query')
 async def _(user: NBUser, who: Player, event_session: Uninfo, compare: timedelta | None = None):
     async with trigger(
         session_persist_id=await get_session_persist_id(event_session),

--- a/nonebot_plugin_tetris_stats/games/top/unbind.py
+++ b/nonebot_plugin_tetris_stats/games/top/unbind.py
@@ -16,12 +16,12 @@ from ...utils.lang import get_lang
 from ...utils.render import render_image
 from ...utils.render.schemas.base import People
 from ...utils.render.schemas.bind import Bind
-from . import alc
+from . import assign
 from .api import Player
 from .constant import GAME_TYPE
 
 
-@alc.assign('TOP.unbind')
+@assign('TOP.unbind')
 async def _(
     nb_user: User,
     event_session: Uninfo,

--- a/nonebot_plugin_tetris_stats/games/tos/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tos/__init__.py
@@ -3,7 +3,7 @@ from nonebot_plugin_alconna import Args, At, Option, Subcommand
 
 from ...utils.duration import parse_duration
 from ...utils.typedefs import Me
-from .. import add_block_handlers, alc, command
+from .. import add_block_handlers, alc, assign, command
 from .api import Player
 from .constant import USER_NAME
 
@@ -91,6 +91,6 @@ alc.shortcut(
     humanized='茶服配置',
 )
 
-add_block_handlers(alc.assign('TOS.query'))
+add_block_handlers(assign('TOS.query'))
 
 from . import bind, config, query, unbind  # noqa: E402, F401

--- a/nonebot_plugin_tetris_stats/games/tos/bind.py
+++ b/nonebot_plugin_tetris_stats/games/tos/bind.py
@@ -15,12 +15,12 @@ from ...utils.lang import get_lang
 from ...utils.render import render_image
 from ...utils.render.schemas.base import People
 from ...utils.render.schemas.bind import Bind
-from . import alc
+from . import assign
 from .api import Player
 from .constant import GAME_TYPE
 
 
-@alc.assign('TOS.bind')
+@assign('TOS.bind')
 async def _(
     nb_user: User,
     account: Player,

--- a/nonebot_plugin_tetris_stats/games/tos/config.py
+++ b/nonebot_plugin_tetris_stats/games/tos/config.py
@@ -9,12 +9,12 @@ from sqlalchemy import select
 
 from ...db import trigger
 from ...i18n import Lang
-from . import alc
+from . import assign
 from .constant import GAME_TYPE
 from .models import TOSUserConfig
 
 
-@alc.assign('TOS.config')
+@assign('TOS.config')
 async def _(user: User, session: async_scoped_session, event_session: Uninfo, compare: timedelta):
     async with trigger(
         session_persist_id=await get_session_persist_id(event_session),

--- a/nonebot_plugin_tetris_stats/games/tos/query.py
+++ b/nonebot_plugin_tetris_stats/games/tos/query.py
@@ -31,7 +31,7 @@ from ...utils.render.schemas.v1.tos.info import Info, Multiplayer, Singleplayer
 from ...utils.time_it import time_it
 from ...utils.timezone import ensure_utc_datetime
 from ...utils.typedefs import Me, Number
-from . import alc
+from . import assign
 from .api import Player
 from .api.models import TOSHistoricalData
 from .api.schemas.user_info import UserInfoSuccess
@@ -46,7 +46,7 @@ UTC = timezone.utc
 def add_special_handlers(
     teaid_prefix: Literal['onebot-', 'kook-', 'discord-', 'qqguild-'], match_event: type[Event]
 ) -> None:
-    @alc.assign('TOS.query')
+    @assign('TOS.query')
     async def _(
         user: NBUser,
         event: Event,
@@ -120,7 +120,7 @@ except ImportError:
     pass
 
 
-@alc.assign('TOS.query')
+@assign('TOS.query')
 async def _(  # noqa: PLR0913, PLR0917
     user: NBUser,
     event: Event,
@@ -157,7 +157,7 @@ async def _(  # noqa: PLR0913, PLR0917
         await (warning + result).finish()
 
 
-@alc.assign('TOS.query')
+@assign('TOS.query')
 async def _(user: NBUser, who: Player, event_session: Uninfo, compare: timedelta | None = None):
     async with (
         trigger(

--- a/nonebot_plugin_tetris_stats/games/tos/unbind.py
+++ b/nonebot_plugin_tetris_stats/games/tos/unbind.py
@@ -15,12 +15,12 @@ from ...utils.lang import get_lang
 from ...utils.render import render_image
 from ...utils.render.schemas.base import People
 from ...utils.render.schemas.bind import Bind
-from . import alc
+from . import assign
 from .api import Player
 from .constant import GAME_TYPE
 
 
-@alc.assign('TOS.unbind')
+@assign('TOS.unbind')
 async def _(
     nb_user: User,
     event_session: Uninfo,

--- a/nonebot_plugin_tetris_stats/permission.py
+++ b/nonebot_plugin_tetris_stats/permission.py
@@ -1,0 +1,10 @@
+from nonebot.internal.params import DependsInner
+from nonebot_plugin_permission import depends_permission  # type: ignore[import-untyped]
+
+
+def permission_name(game: str, command: str) -> str:
+    return f'tetris.{game.upper()}.{command.lower()}'
+
+
+def command_permission(game: str, command: str) -> tuple[DependsInner]:
+    return (depends_permission(permission_name(game, command), default_available=True),)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,15 +18,16 @@ dependencies = [
     "jinja2>=3.1.4",
     "lxml>=5.3.0",
     "msgspec>=0.18.6",
-    "nonebot-plugin-alconna>=0.53.1",
+    "nonebot-plugin-alconna>=0.62.0",
     "nonebot-plugin-apscheduler>=0.5.0",
     "nonebot-plugin-localstore>=0.7.1",
-    "nonebot-plugin-orm>=0.7.6",
+    "nonebot-plugin-orm>=0.8.3",
+    "nonebot-plugin-permission>=0.3.1,<0.4",
     "nonebot-plugin-uninfo>=0.7.4",
-    "nonebot-plugin-user>=0.4.4",
+    "nonebot-plugin-user>=0.6.0",
     "nonebot-plugin-waiter>=0.8.0",
     "nonebot-session-to-uninfo>=0.0.2",
-    "nonebot2[fastapi]>=2.4.4",
+    "nonebot2[fastapi]>=2.5.0",
     "pandas>=2.2.3",
     "pillow>=11.0.0",
     "playwright>=1.48.0",
@@ -42,6 +43,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 keywords = ["nonebot2"]
+
 
 [project.urls]
 Homepage = "https://github.com/A-Minos/nonebot-plugin-tetris-stats"

--- a/tests/test_permission.py
+++ b/tests/test_permission.py
@@ -1,0 +1,117 @@
+import pytest
+from nonebot.internal.params import DependsInner
+from nonebot.params import DependParam, Depends
+
+EXPECTED_PARAMETERLESS = 3
+
+
+def test_permission_plugin_is_loaded() -> None:
+    from nonebot import get_plugin_by_module_name  # noqa: PLC0415
+
+    assert get_plugin_by_module_name('nonebot_plugin_permission') is not None  # noqa: S101
+
+
+def test_permission_name_is_stable() -> None:
+    from nonebot_plugin_tetris_stats.permission import permission_name  # noqa: PLC0415
+
+    assert permission_name('tetrio', 'Rank.Detail') == 'tetris.TETRIO.rank.detail'  # noqa: S101
+
+
+def test_command_permission_is_default_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nonebot_plugin_tetris_stats import permission  # noqa: PLC0415
+
+    async def allowed() -> bool:
+        return True
+
+    dependency: DependsInner = Depends(allowed)
+    calls: list[tuple[str, bool, bool]] = []
+
+    def depends_permission(
+        name: str,
+        *,
+        default_available: bool = True,
+        prompt: bool = False,
+    ) -> DependsInner:
+        calls.append((name, default_available, prompt))
+        return dependency
+
+    monkeypatch.setattr(permission, 'depends_permission', depends_permission)
+
+    assert permission.command_permission('tetrio', 'Rank.Detail') == (dependency,)  # noqa: S101
+    assert calls == [('tetris.TETRIO.rank.detail', True, False)]  # noqa: S101
+
+
+def test_assign_attaches_permission_to_reused_and_nested_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nonebot_plugin_tetris_stats import games  # noqa: PLC0415
+
+    async def allowed() -> bool:
+        return True
+
+    dependency: DependsInner = Depends(allowed)
+    calls: list[tuple[str, str]] = []
+
+    def command_permission(game: str, command: str) -> tuple[DependsInner]:
+        calls.append((game, command))
+        return (dependency,)
+
+    monkeypatch.setattr(games, 'command_permission', command_permission)
+    handler_count = len(games.alc.handlers)
+    try:
+
+        @games.assign('TETRIO.query')
+        async def first_handler() -> None:
+            pass
+
+        @games.assign('TETRIO.query')
+        async def second_handler() -> None:
+            pass
+
+        @games.assign('TETRIO.rank.detail')
+        async def nested_handler() -> None:
+            pass
+
+        assert calls == [  # noqa: S101
+            ('TETRIO', 'query'),
+            ('TETRIO', 'query'),
+            ('TETRIO', 'rank.detail'),
+        ]
+        for handler in games.alc.handlers[-3:]:
+            permission = handler.parameterless[-1]
+            assert isinstance(permission, DependParam)  # noqa: S101
+            assert permission.dependent.call is allowed  # noqa: S101
+    finally:
+        del games.alc.handlers[handler_count:]
+
+
+def test_assign_merges_existing_parameterless_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nonebot_plugin_tetris_stats import games  # noqa: PLC0415
+
+    async def existing() -> bool:
+        return True
+
+    async def allowed() -> bool:
+        return True
+
+    existing_dependency: DependsInner = Depends(existing)
+    permission_dependency: DependsInner = Depends(allowed)
+
+    def command_permission(_game: str, _command: str) -> tuple[DependsInner]:
+        return (permission_dependency,)
+
+    monkeypatch.setattr(games, 'command_permission', command_permission)
+    handler_count = len(games.alc.handlers)
+    try:
+
+        @games.assign('TOP.query')
+        @games.alc.handle(parameterless=(existing_dependency,))
+        async def handler() -> None:
+            pass
+
+        parameterless = games.alc.handlers[-1].parameterless
+        assert len(parameterless) == EXPECTED_PARAMETERLESS  # noqa: S101
+        assert isinstance(parameterless[0], DependParam)  # noqa: S101
+        assert parameterless[0].dependent.call is existing  # noqa: S101
+        assert isinstance(parameterless[-1], DependParam)  # noqa: S101
+        assert parameterless[-1].dependent.call is allowed  # noqa: S101
+    finally:
+        del games.alc.handlers[handler_count:]

--- a/uv.lock
+++ b/uv.lock
@@ -313,6 +313,15 @@ wheels = [
 ]
 
 [[package]]
+name = "arclet-cithun"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/d9/674135ecdd03a1ddf8638b0522be39a1ec973cd3d6aafeef251bccae99f6/arclet_cithun-1.4.0.tar.gz", hash = "sha256:8cafb4591c798f05906ce8827eaf19661bc3e2dae4d754db89c1351ab6fea275", size = 38540, upload-time = "2026-06-10T07:14:49.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/d2/be3839aa49dc4834cbbea1b194ce0563f98654f24faf3c6f024003f2143e/arclet_cithun-1.4.0-py3-none-any.whl", hash = "sha256:b555c804d7b067e63c4fab90ff744be8a1d471569a0f265c9c3b4d39df333db2", size = 38251, upload-time = "2026-06-10T07:14:48.515Z" },
+]
+
+[[package]]
 name = "asgiref"
 version = "3.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -973,7 +982,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -1057,7 +1066,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
@@ -1686,8 +1695,8 @@ name = "httpcore2"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
+    { name = "h11", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
@@ -2490,15 +2499,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "cycler" },
-    { name = "fonttools" },
-    { name = "kiwisolver" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "cycler", marker = "python_full_version < '3.11'" },
+    { name = "fonttools", marker = "python_full_version < '3.11'" },
+    { name = "kiwisolver", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pillow", marker = "python_full_version < '3.11'" },
+    { name = "pyparsing", marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -2580,16 +2589,16 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "cycler" },
-    { name = "fonttools" },
-    { name = "kiwisolver" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "cycler", marker = "python_full_version >= '3.11'" },
+    { name = "fonttools", marker = "python_full_version >= '3.11'" },
+    { name = "kiwisolver", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pillow", marker = "python_full_version >= '3.11'" },
+    { name = "pyparsing", marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/64/f9a391af28f518b11ad45a8a712353c94a0aefce09d3703200e5c54b610a/matplotlib-3.11.1.tar.gz", hash = "sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30", size = 32612045, upload-time = "2026-07-18T03:39:46.63Z" }
 wheels = [
@@ -3209,6 +3218,22 @@ postgresql = [
 ]
 
 [[package]]
+name = "nonebot-plugin-permission"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arclet-cithun" },
+    { name = "nonebot-plugin-alconna" },
+    { name = "nonebot-plugin-orm" },
+    { name = "nonebot-plugin-user" },
+    { name = "nonebot2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/35/70fbdcbbf0ef6e13629c1ef15965d35e3c9a04851dea0bf938ab5890639a/nonebot_plugin_permission-0.3.1.tar.gz", hash = "sha256:187fe1da6a432530976ff057d4a9dcff407ba870202678d85fb70df33d23422b", size = 17135, upload-time = "2026-07-11T14:58:11.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/d4/34a1a0888eed4a9a4ace0574d00e220ee29cbd47247cb2edb6cdcb2e211f/nonebot_plugin_permission-0.3.1-py3-none-any.whl", hash = "sha256:58425880e38c5eb1b1289ecf3c46059741b5552b9215f8c3957cc8c3fb3d1a44", size = 19280, upload-time = "2026-07-11T14:58:09.814Z" },
+]
+
+[[package]]
 name = "nonebot-plugin-session"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3257,6 +3282,7 @@ dependencies = [
     { name = "nonebot-plugin-apscheduler" },
     { name = "nonebot-plugin-localstore" },
     { name = "nonebot-plugin-orm" },
+    { name = "nonebot-plugin-permission" },
     { name = "nonebot-plugin-uninfo" },
     { name = "nonebot-plugin-user" },
     { name = "nonebot-plugin-waiter" },
@@ -3323,15 +3349,16 @@ requires-dist = [
     { name = "lxml", specifier = ">=5.3.0" },
     { name = "msgspec", specifier = ">=0.18.6" },
     { name = "nepattern", specifier = ">=0.7.8" },
-    { name = "nonebot-plugin-alconna", specifier = ">=0.53.1" },
+    { name = "nonebot-plugin-alconna", specifier = ">=0.62.0" },
     { name = "nonebot-plugin-apscheduler", specifier = ">=0.5.0" },
     { name = "nonebot-plugin-localstore", specifier = ">=0.7.1" },
-    { name = "nonebot-plugin-orm", specifier = ">=0.7.6" },
+    { name = "nonebot-plugin-orm", specifier = ">=0.8.3" },
+    { name = "nonebot-plugin-permission", specifier = ">=0.3.1,<0.4" },
     { name = "nonebot-plugin-uninfo", specifier = ">=0.7.4" },
-    { name = "nonebot-plugin-user", specifier = ">=0.4.4" },
+    { name = "nonebot-plugin-user", specifier = ">=0.6.0" },
     { name = "nonebot-plugin-waiter", specifier = ">=0.8.0" },
     { name = "nonebot-session-to-uninfo", specifier = ">=0.0.2" },
-    { name = "nonebot2", extras = ["fastapi"], specifier = ">=2.4.4" },
+    { name = "nonebot2", extras = ["fastapi"], specifier = ">=2.5.0" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "pillow", specifier = ">=11.0.0" },
     { name = "playwright", specifier = ">=1.48.0" },
@@ -3747,10 +3774,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -3825,10 +3852,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/4f/5f3422a2afec5ffc46308b79e53291365a93748b498ac2e58bead0197916/pandas-3.0.5.tar.gz", hash = "sha256:dca3734d6ab7c906e6730f0788b0a1dbb9f2467731f9711f77995c8e9d62d712", size = 4658219, upload-time = "2026-07-22T22:19:28.819Z" }
 wheels = [
@@ -3883,8 +3910,8 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "types-pytz" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "types-pytz", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/92/5d/be23854a73fda69f1dbdda7bc10fbd6f930bd1fa87aaec389f00c901c1e8/pandas_stubs-2.3.3.260113.tar.gz", hash = "sha256:076e3724bcaa73de78932b012ec64b3010463d377fa63116f4e6850643d93800", size = 116131, upload-time = "2026-01-13T22:30:16.704Z" }
 wheels = [
@@ -3913,7 +3940,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/d2/dea4a3a56b7b5f69c5fbca9f14625fcf28e1a39a657e9833d4a10bcac593/pandas_stubs-3.0.5.260730.tar.gz", hash = "sha256:f70a232c57d93a5a2c81f8a53953e10891a5374bc92652277deb325e2e4d0ff3", size = 114631, upload-time = "2026-07-30T14:31:42.271Z" }


### PR DESCRIPTION
## 修改

- 将 `nonebot-plugin-permission>=0.3.1,<0.4` 改为基础依赖，不再提供 optional extra/fallback
- 按真实依赖要求升级 NoneBot、Alconna、ORM、User 最低版本并同步 `uv.lock`
- 新增强类型 `games.assign(path)` seam，迁移全部 29 个 handler 注册调用方
- 保留第三方 `alc.assign` 原接口，不再 monkeypatch，不使用 cast/Any
- 权限名稳定为 `tetris.<GAME>.<command>`，并保持 `default_available=True`
- 直接加载权限插件；测试覆盖插件加载、嵌套/重复路径和既有 parameterless 合并
- 唯一 `type: ignore[import-untyped]` 隔离在无 `py.typed` 的第三方权限插件导入边界

Closes #67

## 验证

- `tests/test_permission.py`：5 passed
- Ruff：通过
- Mypy：151 source files 通过
- BasedPyright：0 errors
- `uv build`：sdist + wheel