### PR TITLE
🌐 完善运行时消息与命令帮助国际化

### DIFF
--- a/nonebot_plugin_tetris_stats/games/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/__init__.py
@@ -52,4 +52,4 @@ async def _(matcher: Matcher, matches: AlcMatches):
 
 @run_postprocessor
 async def _(matcher: Matcher, exception: NeedCatchError):
-    await matcher.send(str(exception))
+    await matcher.send(exception.render())

--- a/nonebot_plugin_tetris_stats/games/tetrio/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/__init__.py
@@ -1,5 +1,7 @@
 from nonebot_plugin_alconna import Subcommand
 
+from ...i18n import Lang
+from ...utils.exception import MessageFormatError
 from .. import alc
 from .. import command as main_command
 from .api import Player
@@ -11,8 +13,7 @@ def get_player(user_id_or_name: str) -> Player:
         return Player(user_id=user_id_or_name, trust=True)
     if USER_NAME.match(user_id_or_name):
         return Player(user_name=user_id_or_name, trust=True)
-    msg = '用户名/ID不合法'
-    raise ValueError(msg)
+    raise MessageFormatError(Lang.error.MessageFormatError.TETR_IO)
 
 
 command = Subcommand(

--- a/nonebot_plugin_tetris_stats/games/tetrio/api/leaderboards.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/api/leaderboards.py
@@ -5,6 +5,7 @@ from nonebot import __version__ as __nonebot_version__
 from nonebot.compat import type_validate_json
 from yarl import URL
 
+from ....i18n import Lang
 from ....utils.exception import RequestError
 from ....version import __version__
 from ..constant import BASE_URL
@@ -33,8 +34,7 @@ async def by(
         ),
     )
     if isinstance(model, FailedModel):
-        msg = f'排行榜信息请求错误:\n{model.error}'
-        raise RequestError(msg)
+        raise RequestError(Lang.error.RequestError.TETR_IO.leaderboard, detail=model.error)
     return model
 
 
@@ -84,8 +84,7 @@ async def records(
                 ),
             )
     if isinstance(model, FailedModel):
-        msg = f'排行榜信息请求错误:\n{model.error}'
-        raise RequestError(msg)
+        raise RequestError(Lang.error.RequestError.TETR_IO.leaderboard, detail=model.error)
     return model
 
 

--- a/nonebot_plugin_tetris_stats/games/tetrio/api/player.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/api/player.py
@@ -6,6 +6,7 @@ from async_lru import alru_cache
 from nonebot.compat import type_validate_json
 
 from ....db import anti_duplicate_add
+from ....i18n import Lang
 from ....utils.exception import RequestError
 from ....utils.timezone import ensure_utc_datetime
 from ..constant import BASE_URL, USER_ID, USER_NAME
@@ -118,8 +119,7 @@ class Player:
             raw_user_info = await Cache.get(BASE_URL / 'users' / self._request_user_parameter)
             user_info: UserInfo = type_validate_json(UserInfo, raw_user_info)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
             if isinstance(user_info, FailedModel):
-                msg = f'用户信息请求错误:\n{user_info.error}'
-                raise RequestError(msg)
+                raise RequestError(Lang.error.RequestError.TETR_IO.user_info, detail=user_info.error)
             self._user_info = user_info
             await anti_duplicate_add(
                 TETRIOHistoricalData(
@@ -152,8 +152,7 @@ class Player:
                 raw_summaries,
             )
             if isinstance(summaries, FailedModel):
-                msg = f'用户Summaries数据请求错误:\n{summaries.error}'
-                raise RequestError(msg)
+                raise RequestError(Lang.error.RequestError.TETR_IO.summaries, detail=summaries.error)
             self._summaries[summaries_type] = summaries
             await anti_duplicate_add(
                 TETRIOHistoricalData(
@@ -172,8 +171,7 @@ class Player:
                 await Cache.get(BASE_URL / 'labs/leagueflow' / self._request_user_parameter),
             )
             if isinstance(leagueflow, FailedModel):
-                msg = f'League 历史记录请求错误:\n{leagueflow.error}'
-                raise RequestError(msg)
+                raise RequestError(Lang.error.RequestError.TETR_IO.league_history, detail=leagueflow.error)
             self._leagueflow = leagueflow
         return self._leagueflow
 
@@ -238,8 +236,7 @@ class Player:
             raw_records = await Cache.get(url)
             records: RecordsSoloSuccessModel | FailedModel = type_validate_json(SoloRecord, raw_records)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
             if isinstance(records, FailedModel):
-                msg = f'用户Records数据请求错误:\n{records.error}'
-                raise RequestError(msg)
+                raise RequestError(Lang.error.RequestError.TETR_IO.records, detail=records.error)
             self._records[record_key] = records
             await anti_duplicate_add(
                 TETRIOHistoricalData(

--- a/nonebot_plugin_tetris_stats/games/tetrio/unbind.py
+++ b/nonebot_plugin_tetris_stats/games/tetrio/unbind.py
@@ -16,7 +16,7 @@ from ...db import query_bind_info, remove_bind, trigger
 from ...i18n import Lang
 from ...utils.host import get_self_netloc
 from ...utils.image import get_avatar
-from ...utils.lang import get_lang
+from ...utils.lang import get_lang, get_unbind_choices
 from ...utils.render import render_image
 from ...utils.render.schemas.base import Avatar, People
 from ...utils.render.schemas.bind import Bind
@@ -46,8 +46,9 @@ async def _(nb_user: User, event_session: Uninfo, interface: QryItrface):
     ):
         if (bind := await query_bind_info(session=session, user=nb_user, game_platform=GAME_TYPE)) is None:
             await UniMessage(Lang.bind.no_account(game='TETR.IO')).finish()
-        resp = await suggest(Lang.bind.confirm_unbind(), ['是', '否'])
-        if resp is None or resp.extract_plain_text() == '否':
+        choices = get_unbind_choices()
+        resp = await suggest(Lang.bind.confirm_unbind(), list(choices))
+        if choices.is_cancelled(resp.extract_plain_text() if resp is not None else None):
             return
         player = Player(user_id=bind.game_account, trust=True)
         user = await player.user

--- a/nonebot_plugin_tetris_stats/games/top/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/top/__init__.py
@@ -1,7 +1,9 @@
 from arclet.alconna import Arg, ArgFlag
 from nonebot_plugin_alconna import Args, At, Option, Subcommand
 
+from ...i18n import Lang
 from ...utils.duration import parse_duration
+from ...utils.exception import MessageFormatError
 from ...utils.typedefs import Me
 from .. import add_block_handlers, alc, command
 from .api import Player
@@ -11,8 +13,7 @@ from .constant import USER_NAME
 def get_player(name: str) -> Player:
     if USER_NAME.match(name):
         return Player(user_name=name, trust=True)
-    msg = '用户名/ID不合法'
-    raise ValueError(msg)
+    raise MessageFormatError(Lang.error.MessageFormatError.TOP)
 
 
 command.add(

--- a/nonebot_plugin_tetris_stats/games/top/unbind.py
+++ b/nonebot_plugin_tetris_stats/games/top/unbind.py
@@ -12,7 +12,7 @@ from ...config.config import global_config
 from ...db import query_bind_info, remove_bind, trigger
 from ...i18n import Lang
 from ...utils.image import get_avatar
-from ...utils.lang import get_lang
+from ...utils.lang import get_lang, get_unbind_choices
 from ...utils.render import render_image
 from ...utils.render.schemas.base import People
 from ...utils.render.schemas.bind import Bind
@@ -38,8 +38,9 @@ async def _(
     ):
         if (bind := await query_bind_info(session=session, user=nb_user, game_platform=GAME_TYPE)) is None:
             await UniMessage(Lang.bind.no_account(game='TOP')).finish()
-        resp = await suggest(Lang.bind.confirm_unbind(), ['是', '否'])
-        if resp is None or resp.extract_plain_text() == '否':
+        choices = get_unbind_choices()
+        resp = await suggest(Lang.bind.confirm_unbind(), list(choices))
+        if choices.is_cancelled(resp.extract_plain_text() if resp is not None else None):
             return
         player = Player(user_name=bind.game_account, trust=True)
         user = await player.user

--- a/nonebot_plugin_tetris_stats/games/tos/__init__.py
+++ b/nonebot_plugin_tetris_stats/games/tos/__init__.py
@@ -1,7 +1,9 @@
 from arclet.alconna import Arg, ArgFlag
 from nonebot_plugin_alconna import Args, At, Option, Subcommand
 
+from ...i18n import Lang
 from ...utils.duration import parse_duration
+from ...utils.exception import MessageFormatError
 from ...utils.typedefs import Me
 from .. import add_block_handlers, alc, command
 from .api import Player
@@ -16,8 +18,7 @@ def get_player(teaid_or_name: str) -> Player:
         return Player(teaid=teaid_or_name, trust=True)
     if USER_NAME.match(teaid_or_name) and not teaid_or_name.isdigit() and 2 <= len(teaid_or_name) <= 18:  # noqa: PLR2004
         return Player(user_name=teaid_or_name, trust=True)
-    msg = '用户名/ID不合法'
-    raise ValueError(msg)
+    raise MessageFormatError(Lang.error.MessageFormatError.TOS)
 
 
 command.add(

--- a/nonebot_plugin_tetris_stats/games/tos/api/player.py
+++ b/nonebot_plugin_tetris_stats/games/tos/api/player.py
@@ -7,6 +7,7 @@ from yarl import URL
 
 from ....config.config import config
 from ....db import anti_duplicate_add
+from ....i18n import Lang
 from ....utils.exception import RequestError
 from ....utils.request import Request
 from ..constant import BASE_URL, USER_NAME
@@ -70,8 +71,7 @@ class Player:
             )
             user_info: UserInfo = type_validate_json(UserInfo, raw_user_info)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
             if not isinstance(user_info, UserInfoSuccess):
-                msg = f'用户信息请求错误:\n{user_info.error}'
-                raise RequestError(msg)
+                raise RequestError(Lang.error.RequestError.TOS.user_info, detail=user_info.error)
             self._user_info = user_info
             await anti_duplicate_add(
                 TOSHistoricalData(

--- a/nonebot_plugin_tetris_stats/games/tos/unbind.py
+++ b/nonebot_plugin_tetris_stats/games/tos/unbind.py
@@ -10,8 +10,9 @@ from nonebot_plugin_waiter import suggest  # type: ignore[import-untyped]
 
 from ...config.config import global_config
 from ...db import query_bind_info, remove_bind, trigger
+from ...i18n import Lang
 from ...utils.image import get_avatar
-from ...utils.lang import get_lang
+from ...utils.lang import get_lang, get_unbind_choices
 from ...utils.render import render_image
 from ...utils.render.schemas.base import People
 from ...utils.render.schemas.bind import Bind
@@ -36,9 +37,10 @@ async def _(
         get_session() as session,
     ):
         if (bind := await query_bind_info(session=session, user=nb_user, game_platform=GAME_TYPE)) is None:
-            await UniMessage('您还未绑定 TOS 账号').finish()
-        resp = await suggest('您确定要解绑吗?', ['是', '否'])
-        if resp is None or resp.extract_plain_text() == '否':
+            await UniMessage(Lang.bind.no_account(game='TOS')).finish()
+        choices = get_unbind_choices()
+        resp = await suggest(Lang.bind.confirm_unbind(), list(choices))
+        if choices.is_cancelled(resp.extract_plain_text() if resp is not None else None):
             return
         player = Player(user_name=bind.game_account, trust=True)
         user = await player.user
@@ -62,7 +64,7 @@ async def _(
                         ),
                         name=bot_user.nick or bot_user.name or choice(list(global_config.nickname) or ['bot']),
                     ),
-                    prompt='茶服绑定{游戏ID}',
+                    prompt=Lang.prompt.tos_bind(),
                     lang=get_lang(),
                 ),
             )

--- a/nonebot_plugin_tetris_stats/i18n/.lang.schema.json
+++ b/nonebot_plugin_tetris_stats/i18n/.lang.schema.json
@@ -63,6 +63,98 @@
               "title": "TOP",
               "description": "value of lang item type 'TOP'",
               "type": "string"
+            },
+            "duration": {
+              "title": "duration",
+              "description": "value of lang item type 'duration'",
+              "type": "string"
+            }
+          }
+        },
+        "RequestError": {
+          "title": "Requesterror",
+          "description": "Scope 'RequestError' of lang item",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "request": {
+              "title": "Request",
+              "description": "Scope 'request' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "api": {
+                  "title": "api",
+                  "description": "value of lang item type 'api'",
+                  "type": "string"
+                },
+                "cloudflare": {
+                  "title": "cloudflare",
+                  "description": "value of lang item type 'cloudflare'",
+                  "type": "string"
+                },
+                "response": {
+                  "title": "response",
+                  "description": "value of lang item type 'response'",
+                  "type": "string"
+                },
+                "transport": {
+                  "title": "transport",
+                  "description": "value of lang item type 'transport'",
+                  "type": "string"
+                },
+                "failover": {
+                  "title": "failover",
+                  "description": "value of lang item type 'failover'",
+                  "type": "string"
+                }
+              }
+            },
+            "TETR.IO": {
+              "title": "Tetr.io",
+              "description": "Scope 'TETR.IO' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "leaderboard": {
+                  "title": "leaderboard",
+                  "description": "value of lang item type 'leaderboard'",
+                  "type": "string"
+                },
+                "user_info": {
+                  "title": "user_info",
+                  "description": "value of lang item type 'user_info'",
+                  "type": "string"
+                },
+                "summaries": {
+                  "title": "summaries",
+                  "description": "value of lang item type 'summaries'",
+                  "type": "string"
+                },
+                "league_history": {
+                  "title": "league_history",
+                  "description": "value of lang item type 'league_history'",
+                  "type": "string"
+                },
+                "records": {
+                  "title": "records",
+                  "description": "value of lang item type 'records'",
+                  "type": "string"
+                }
+              }
+            },
+            "TOS": {
+              "title": "Tos",
+              "description": "Scope 'TOS' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "user_info": {
+                  "title": "user_info",
+                  "description": "value of lang item type 'user_info'",
+                  "type": "string"
+                }
+              }
             }
           }
         }
@@ -78,6 +170,1344 @@
           "title": "template_language",
           "description": "value of lang item type 'template_language'",
           "type": "string"
+        }
+      }
+    },
+    "bind": {
+      "title": "Bind",
+      "description": "Scope 'bind' of lang item",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "not_found": {
+          "title": "not_found",
+          "description": "value of lang item type 'not_found'",
+          "type": "string"
+        },
+        "no_account": {
+          "title": "no_account",
+          "description": "value of lang item type 'no_account'",
+          "type": "string"
+        },
+        "confirm_unbind": {
+          "title": "confirm_unbind",
+          "description": "value of lang item type 'confirm_unbind'",
+          "type": "string"
+        },
+        "confirm_yes": {
+          "title": "confirm_yes",
+          "description": "value of lang item type 'confirm_yes'",
+          "type": "string"
+        },
+        "confirm_no": {
+          "title": "confirm_no",
+          "description": "value of lang item type 'confirm_no'",
+          "type": "string"
+        },
+        "config_success": {
+          "title": "config_success",
+          "description": "value of lang item type 'config_success'",
+          "type": "string"
+        },
+        "verify_already": {
+          "title": "verify_already",
+          "description": "value of lang item type 'verify_already'",
+          "type": "string"
+        },
+        "verify_failed": {
+          "title": "verify_failed",
+          "description": "value of lang item type 'verify_failed'",
+          "type": "string"
+        },
+        "only_discord": {
+          "title": "only_discord",
+          "description": "value of lang item type 'only_discord'",
+          "type": "string"
+        }
+      }
+    },
+    "record": {
+      "title": "Record",
+      "description": "Scope 'record' of lang item",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "not_found": {
+          "title": "not_found",
+          "description": "value of lang item type 'not_found'",
+          "type": "string"
+        },
+        "blitz": {
+          "title": "blitz",
+          "description": "value of lang item type 'blitz'",
+          "type": "string"
+        },
+        "sprint": {
+          "title": "sprint",
+          "description": "value of lang item type 'sprint'",
+          "type": "string"
+        }
+      }
+    },
+    "stats": {
+      "title": "Stats",
+      "description": "Scope 'stats' of lang item",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "user_info": {
+          "title": "user_info",
+          "description": "value of lang item type 'user_info'",
+          "type": "string"
+        },
+        "no_rank": {
+          "title": "no_rank",
+          "description": "value of lang item type 'no_rank'",
+          "type": "string"
+        },
+        "rank_info": {
+          "title": "rank_info",
+          "description": "value of lang item type 'rank_info'",
+          "type": "string"
+        },
+        "no_game": {
+          "title": "no_game",
+          "description": "value of lang item type 'no_game'",
+          "type": "string"
+        },
+        "recent_games": {
+          "title": "recent_games",
+          "description": "value of lang item type 'recent_games'",
+          "type": "string"
+        },
+        "daily_stats": {
+          "title": "daily_stats",
+          "description": "value of lang item type 'daily_stats'",
+          "type": "string"
+        },
+        "no_daily": {
+          "title": "no_daily",
+          "description": "value of lang item type 'no_daily'",
+          "type": "string"
+        },
+        "history_stats": {
+          "title": "history_stats",
+          "description": "value of lang item type 'history_stats'",
+          "type": "string"
+        },
+        "no_history": {
+          "title": "no_history",
+          "description": "value of lang item type 'no_history'",
+          "type": "string"
+        },
+        "lpm": {
+          "title": "lpm",
+          "description": "value of lang item type 'lpm'",
+          "type": "string"
+        },
+        "apm": {
+          "title": "apm",
+          "description": "value of lang item type 'apm'",
+          "type": "string"
+        },
+        "adpm": {
+          "title": "adpm",
+          "description": "value of lang item type 'adpm'",
+          "type": "string"
+        },
+        "sprint_pb": {
+          "title": "sprint_pb",
+          "description": "value of lang item type 'sprint_pb'",
+          "type": "string"
+        },
+        "marathon_pb": {
+          "title": "marathon_pb",
+          "description": "value of lang item type 'marathon_pb'",
+          "type": "string"
+        },
+        "challenge_pb": {
+          "title": "challenge_pb",
+          "description": "value of lang item type 'challenge_pb'",
+          "type": "string"
+        }
+      }
+    },
+    "template_ui": {
+      "title": "Template_ui",
+      "description": "Scope 'template_ui' of lang item",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "invalid_tag": {
+          "title": "invalid_tag",
+          "description": "value of lang item type 'invalid_tag'",
+          "type": "string"
+        },
+        "update_success": {
+          "title": "update_success",
+          "description": "value of lang item type 'update_success'",
+          "type": "string"
+        },
+        "update_failed": {
+          "title": "update_failed",
+          "description": "value of lang item type 'update_failed'",
+          "type": "string"
+        }
+      }
+    },
+    "help": {
+      "title": "Help",
+      "description": "Scope 'help' of lang item",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "usage": {
+          "title": "usage",
+          "description": "value of lang item type 'usage'",
+          "type": "string"
+        }
+      }
+    },
+    "prompt": {
+      "title": "Prompt",
+      "description": "Scope 'prompt' of lang item",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "io_check": {
+          "title": "io_check",
+          "description": "value of lang item type 'io_check'",
+          "type": "string"
+        },
+        "io_bind": {
+          "title": "io_bind",
+          "description": "value of lang item type 'io_bind'",
+          "type": "string"
+        },
+        "top_check": {
+          "title": "top_check",
+          "description": "value of lang item type 'top_check'",
+          "type": "string"
+        },
+        "top_bind": {
+          "title": "top_bind",
+          "description": "value of lang item type 'top_bind'",
+          "type": "string"
+        },
+        "tos_check": {
+          "title": "tos_check",
+          "description": "value of lang item type 'tos_check'",
+          "type": "string"
+        },
+        "tos_bind": {
+          "title": "tos_bind",
+          "description": "value of lang item type 'tos_bind'",
+          "type": "string"
+        }
+      }
+    },
+    "retry": {
+      "title": "Retry",
+      "description": "Scope 'retry' of lang item",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "message": {
+          "title": "message",
+          "description": "value of lang item type 'message'",
+          "type": "string"
+        },
+        "screenshot": {
+          "title": "screenshot",
+          "description": "value of lang item type 'screenshot'",
+          "type": "string"
+        }
+      }
+    },
+    "command": {
+      "title": "Command",
+      "description": "Scope 'command' of lang item",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "root": {
+          "title": "Root",
+          "description": "Scope 'root' of lang item",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "title": "description",
+              "description": "value of lang item type 'description'",
+              "type": "string"
+            },
+            "plugin_description": {
+              "title": "plugin_description",
+              "description": "value of lang item type 'plugin_description'",
+              "type": "string"
+            },
+            "plugin_usage": {
+              "title": "plugin_usage",
+              "description": "value of lang item type 'plugin_usage'",
+              "type": "string"
+            }
+          }
+        },
+        "tetrio": {
+          "title": "Tetrio",
+          "description": "Scope 'tetrio' of lang item",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "title": "description",
+              "description": "value of lang item type 'description'",
+              "type": "string"
+            },
+            "bind": {
+              "title": "Bind",
+              "description": "Scope 'bind' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "title": "description",
+                  "description": "value of lang item type 'description'",
+                  "type": "string"
+                },
+                "args": {
+                  "title": "Args",
+                  "description": "Scope 'args' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "account": {
+                      "title": "Account",
+                      "description": "Scope 'account' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "notice": {
+                          "title": "notice",
+                          "description": "value of lang item type 'notice'",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "shortcut": {
+                  "title": "shortcut",
+                  "description": "value of lang item type 'shortcut'",
+                  "type": "string"
+                }
+              }
+            },
+            "config": {
+              "title": "Config",
+              "description": "Scope 'config' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "title": "description",
+                  "description": "value of lang item type 'description'",
+                  "type": "string"
+                },
+                "options": {
+                  "title": "Options",
+                  "description": "Scope 'options' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "default_template": {
+                      "title": "Default_template",
+                      "description": "Scope 'default_template' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "help": {
+                          "title": "help",
+                          "description": "value of lang item type 'help'",
+                          "type": "string"
+                        },
+                        "args": {
+                          "title": "Args",
+                          "description": "Scope 'args' of lang item",
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "template": {
+                              "title": "Template",
+                              "description": "Scope 'template' of lang item",
+                              "type": "object",
+                              "additionalProperties": false,
+                              "properties": {
+                                "notice": {
+                                  "title": "notice",
+                                  "description": "value of lang item type 'notice'",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "default_compare": {
+                      "title": "Default_compare",
+                      "description": "Scope 'default_compare' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "help": {
+                          "title": "help",
+                          "description": "value of lang item type 'help'",
+                          "type": "string"
+                        },
+                        "args": {
+                          "title": "Args",
+                          "description": "Scope 'args' of lang item",
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "compare": {
+                              "title": "Compare",
+                              "description": "Scope 'compare' of lang item",
+                              "type": "object",
+                              "additionalProperties": false,
+                              "properties": {
+                                "notice": {
+                                  "title": "notice",
+                                  "description": "value of lang item type 'notice'",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "shortcut": {
+                  "title": "shortcut",
+                  "description": "value of lang item type 'shortcut'",
+                  "type": "string"
+                }
+              }
+            },
+            "list": {
+              "title": "List",
+              "description": "Scope 'list' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "title": "description",
+                  "description": "value of lang item type 'description'",
+                  "type": "string"
+                },
+                "options": {
+                  "title": "Options",
+                  "description": "Scope 'options' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "max_tr": {
+                      "title": "Max_tr",
+                      "description": "Scope 'max_tr' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "help": {
+                          "title": "help",
+                          "description": "value of lang item type 'help'",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "min_tr": {
+                      "title": "Min_tr",
+                      "description": "Scope 'min_tr' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "help": {
+                          "title": "help",
+                          "description": "value of lang item type 'help'",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "limit": {
+                      "title": "Limit",
+                      "description": "Scope 'limit' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "help": {
+                          "title": "help",
+                          "description": "value of lang item type 'help'",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "country": {
+                      "title": "Country",
+                      "description": "Scope 'country' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "help": {
+                          "title": "help",
+                          "description": "value of lang item type 'help'",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "sort": {
+                      "title": "Sort",
+                      "description": "Scope 'sort' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "help": {
+                          "title": "help",
+                          "description": "value of lang item type 'help'",
+                          "type": "string"
+                        },
+                        "args": {
+                          "title": "Args",
+                          "description": "Scope 'args' of lang item",
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "sort": {
+                              "title": "Sort",
+                              "description": "Scope 'sort' of lang item",
+                              "type": "object",
+                              "additionalProperties": false,
+                              "properties": {
+                                "notice": {
+                                  "title": "notice",
+                                  "description": "value of lang item type 'notice'",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "query": {
+              "title": "Query",
+              "description": "Scope 'query' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "title": "description",
+                  "description": "value of lang item type 'description'",
+                  "type": "string"
+                },
+                "args": {
+                  "title": "Args",
+                  "description": "Scope 'args' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "who": {
+                      "title": "Who",
+                      "description": "Scope 'who' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "notice": {
+                          "title": "notice",
+                          "description": "value of lang item type 'notice'",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "options": {
+                  "title": "Options",
+                  "description": "Scope 'options' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "template": {
+                      "title": "Template",
+                      "description": "Scope 'template' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "help": {
+                          "title": "help",
+                          "description": "value of lang item type 'help'",
+                          "type": "string"
+                        },
+                        "args": {
+                          "title": "Args",
+                          "description": "Scope 'args' of lang item",
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "template": {
+                              "title": "Template",
+                              "description": "Scope 'template' of lang item",
+                              "type": "object",
+                              "additionalProperties": false,
+                              "properties": {
+                                "notice": {
+                                  "title": "notice",
+                                  "description": "value of lang item type 'notice'",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "compare": {
+                      "title": "Compare",
+                      "description": "Scope 'compare' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "help": {
+                          "title": "help",
+                          "description": "value of lang item type 'help'",
+                          "type": "string"
+                        },
+                        "args": {
+                          "title": "Args",
+                          "description": "Scope 'args' of lang item",
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "compare": {
+                              "title": "Compare",
+                              "description": "Scope 'compare' of lang item",
+                              "type": "object",
+                              "additionalProperties": false,
+                              "properties": {
+                                "notice": {
+                                  "title": "notice",
+                                  "description": "value of lang item type 'notice'",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "shortcut": {
+                  "title": "shortcut",
+                  "description": "value of lang item type 'shortcut'",
+                  "type": "string"
+                }
+              }
+            },
+            "rank": {
+              "title": "Rank",
+              "description": "Scope 'rank' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "title": "description",
+                  "description": "value of lang item type 'description'",
+                  "type": "string"
+                },
+                "all": {
+                  "title": "All",
+                  "description": "Scope 'all' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "description": {
+                      "title": "description",
+                      "description": "value of lang item type 'description'",
+                      "type": "string"
+                    },
+                    "options": {
+                      "title": "Options",
+                      "description": "Scope 'options' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "template": {
+                          "title": "Template",
+                          "description": "Scope 'template' of lang item",
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "help": {
+                              "title": "help",
+                              "description": "value of lang item type 'help'",
+                              "type": "string"
+                            },
+                            "args": {
+                              "title": "Args",
+                              "description": "Scope 'args' of lang item",
+                              "type": "object",
+                              "additionalProperties": false,
+                              "properties": {
+                                "template": {
+                                  "title": "Template",
+                                  "description": "Scope 'template' of lang item",
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "notice": {
+                                      "title": "notice",
+                                      "description": "value of lang item type 'notice'",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "detail": {
+                  "title": "Detail",
+                  "description": "Scope 'detail' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "description": {
+                      "title": "description",
+                      "description": "value of lang item type 'description'",
+                      "type": "string"
+                    },
+                    "args": {
+                      "title": "Args",
+                      "description": "Scope 'args' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "rank": {
+                          "title": "Rank",
+                          "description": "Scope 'rank' of lang item",
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "notice": {
+                              "title": "notice",
+                              "description": "value of lang item type 'notice'",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "shortcut": {
+                  "title": "shortcut",
+                  "description": "value of lang item type 'shortcut'",
+                  "type": "string"
+                }
+              }
+            },
+            "record": {
+              "title": "Record",
+              "description": "Scope 'record' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "args": {
+                  "title": "Args",
+                  "description": "Scope 'args' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "who": {
+                      "title": "Who",
+                      "description": "Scope 'who' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "notice": {
+                          "title": "notice",
+                          "description": "value of lang item type 'notice'",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "options": {
+                  "title": "Options",
+                  "description": "Scope 'options' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "type": {
+                      "title": "Type",
+                      "description": "Scope 'type' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "help": {
+                          "title": "help",
+                          "description": "value of lang item type 'help'",
+                          "type": "string"
+                        },
+                        "args": {
+                          "title": "Args",
+                          "description": "Scope 'args' of lang item",
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "record_type": {
+                              "title": "Record_type",
+                              "description": "Scope 'record_type' of lang item",
+                              "type": "object",
+                              "additionalProperties": false,
+                              "properties": {
+                                "notice": {
+                                  "title": "notice",
+                                  "description": "value of lang item type 'notice'",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "index": {
+                      "title": "Index",
+                      "description": "Scope 'index' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "help": {
+                          "title": "help",
+                          "description": "value of lang item type 'help'",
+                          "type": "string"
+                        },
+                        "args": {
+                          "title": "Args",
+                          "description": "Scope 'args' of lang item",
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "index": {
+                              "title": "Index",
+                              "description": "Scope 'index' of lang item",
+                              "type": "object",
+                              "additionalProperties": false,
+                              "properties": {
+                                "notice": {
+                                  "title": "notice",
+                                  "description": "value of lang item type 'notice'",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "shortcuts": {
+                  "title": "Shortcuts",
+                  "description": "Scope 'shortcuts' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "blitz": {
+                      "title": "blitz",
+                      "description": "value of lang item type 'blitz'",
+                      "type": "string"
+                    },
+                    "sprint": {
+                      "title": "sprint",
+                      "description": "value of lang item type 'sprint'",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "unbind": {
+              "title": "Unbind",
+              "description": "Scope 'unbind' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "title": "description",
+                  "description": "value of lang item type 'description'",
+                  "type": "string"
+                },
+                "shortcut": {
+                  "title": "shortcut",
+                  "description": "value of lang item type 'shortcut'",
+                  "type": "string"
+                }
+              }
+            },
+            "verify": {
+              "title": "Verify",
+              "description": "Scope 'verify' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "title": "description",
+                  "description": "value of lang item type 'description'",
+                  "type": "string"
+                },
+                "shortcut": {
+                  "title": "shortcut",
+                  "description": "value of lang item type 'shortcut'",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "top": {
+          "title": "Top",
+          "description": "Scope 'top' of lang item",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "title": "description",
+              "description": "value of lang item type 'description'",
+              "type": "string"
+            },
+            "bind": {
+              "title": "Bind",
+              "description": "Scope 'bind' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "title": "description",
+                  "description": "value of lang item type 'description'",
+                  "type": "string"
+                },
+                "args": {
+                  "title": "Args",
+                  "description": "Scope 'args' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "account": {
+                      "title": "Account",
+                      "description": "Scope 'account' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "notice": {
+                          "title": "notice",
+                          "description": "value of lang item type 'notice'",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "shortcut": {
+                  "title": "shortcut",
+                  "description": "value of lang item type 'shortcut'",
+                  "type": "string"
+                }
+              }
+            },
+            "unbind": {
+              "title": "Unbind",
+              "description": "Scope 'unbind' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "title": "description",
+                  "description": "value of lang item type 'description'",
+                  "type": "string"
+                },
+                "shortcut": {
+                  "title": "shortcut",
+                  "description": "value of lang item type 'shortcut'",
+                  "type": "string"
+                }
+              }
+            },
+            "config": {
+              "title": "Config",
+              "description": "Scope 'config' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "title": "description",
+                  "description": "value of lang item type 'description'",
+                  "type": "string"
+                },
+                "options": {
+                  "title": "Options",
+                  "description": "Scope 'options' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "default_compare": {
+                      "title": "Default_compare",
+                      "description": "Scope 'default_compare' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "help": {
+                          "title": "help",
+                          "description": "value of lang item type 'help'",
+                          "type": "string"
+                        },
+                        "args": {
+                          "title": "Args",
+                          "description": "Scope 'args' of lang item",
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "compare": {
+                              "title": "Compare",
+                              "description": "Scope 'compare' of lang item",
+                              "type": "object",
+                              "additionalProperties": false,
+                              "properties": {
+                                "notice": {
+                                  "title": "notice",
+                                  "description": "value of lang item type 'notice'",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "shortcut": {
+                  "title": "shortcut",
+                  "description": "value of lang item type 'shortcut'",
+                  "type": "string"
+                }
+              }
+            },
+            "query": {
+              "title": "Query",
+              "description": "Scope 'query' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "title": "description",
+                  "description": "value of lang item type 'description'",
+                  "type": "string"
+                },
+                "args": {
+                  "title": "Args",
+                  "description": "Scope 'args' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "who": {
+                      "title": "Who",
+                      "description": "Scope 'who' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "notice": {
+                          "title": "notice",
+                          "description": "value of lang item type 'notice'",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "options": {
+                  "title": "Options",
+                  "description": "Scope 'options' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "compare": {
+                      "title": "Compare",
+                      "description": "Scope 'compare' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "help": {
+                          "title": "help",
+                          "description": "value of lang item type 'help'",
+                          "type": "string"
+                        },
+                        "args": {
+                          "title": "Args",
+                          "description": "Scope 'args' of lang item",
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "compare": {
+                              "title": "Compare",
+                              "description": "Scope 'compare' of lang item",
+                              "type": "object",
+                              "additionalProperties": false,
+                              "properties": {
+                                "notice": {
+                                  "title": "notice",
+                                  "description": "value of lang item type 'notice'",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "shortcut": {
+                  "title": "shortcut",
+                  "description": "value of lang item type 'shortcut'",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "tos": {
+          "title": "Tos",
+          "description": "Scope 'tos' of lang item",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "title": "description",
+              "description": "value of lang item type 'description'",
+              "type": "string"
+            },
+            "bind": {
+              "title": "Bind",
+              "description": "Scope 'bind' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "title": "description",
+                  "description": "value of lang item type 'description'",
+                  "type": "string"
+                },
+                "args": {
+                  "title": "Args",
+                  "description": "Scope 'args' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "account": {
+                      "title": "Account",
+                      "description": "Scope 'account' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "notice": {
+                          "title": "notice",
+                          "description": "value of lang item type 'notice'",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "shortcut": {
+                  "title": "shortcut",
+                  "description": "value of lang item type 'shortcut'",
+                  "type": "string"
+                }
+              }
+            },
+            "unbind": {
+              "title": "Unbind",
+              "description": "Scope 'unbind' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "title": "description",
+                  "description": "value of lang item type 'description'",
+                  "type": "string"
+                },
+                "shortcut": {
+                  "title": "shortcut",
+                  "description": "value of lang item type 'shortcut'",
+                  "type": "string"
+                }
+              }
+            },
+            "config": {
+              "title": "Config",
+              "description": "Scope 'config' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "title": "description",
+                  "description": "value of lang item type 'description'",
+                  "type": "string"
+                },
+                "options": {
+                  "title": "Options",
+                  "description": "Scope 'options' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "default_compare": {
+                      "title": "Default_compare",
+                      "description": "Scope 'default_compare' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "help": {
+                          "title": "help",
+                          "description": "value of lang item type 'help'",
+                          "type": "string"
+                        },
+                        "args": {
+                          "title": "Args",
+                          "description": "Scope 'args' of lang item",
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "compare": {
+                              "title": "Compare",
+                              "description": "Scope 'compare' of lang item",
+                              "type": "object",
+                              "additionalProperties": false,
+                              "properties": {
+                                "notice": {
+                                  "title": "notice",
+                                  "description": "value of lang item type 'notice'",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "shortcut": {
+                  "title": "shortcut",
+                  "description": "value of lang item type 'shortcut'",
+                  "type": "string"
+                }
+              }
+            },
+            "query": {
+              "title": "Query",
+              "description": "Scope 'query' of lang item",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "title": "description",
+                  "description": "value of lang item type 'description'",
+                  "type": "string"
+                },
+                "args": {
+                  "title": "Args",
+                  "description": "Scope 'args' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "who": {
+                      "title": "Who",
+                      "description": "Scope 'who' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "notice": {
+                          "title": "notice",
+                          "description": "value of lang item type 'notice'",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "options": {
+                  "title": "Options",
+                  "description": "Scope 'options' of lang item",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "compare": {
+                      "title": "Compare",
+                      "description": "Scope 'compare' of lang item",
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "help": {
+                          "title": "help",
+                          "description": "value of lang item type 'help'",
+                          "type": "string"
+                        },
+                        "args": {
+                          "title": "Args",
+                          "description": "Scope 'args' of lang item",
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "compare": {
+                              "title": "Compare",
+                              "description": "Scope 'compare' of lang item",
+                              "type": "object",
+                              "additionalProperties": false,
+                              "properties": {
+                                "notice": {
+                                  "title": "notice",
+                                  "description": "value of lang item type 'notice'",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "shortcut": {
+                  "title": "shortcut",
+                  "description": "value of lang item type 'shortcut'",
+                  "type": "string"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/nonebot_plugin_tetris_stats/i18n/.template.json
+++ b/nonebot_plugin_tetris_stats/i18n/.template.json
@@ -4,21 +4,79 @@
     {
       "scope": "interaction",
       "types": [
-        { "subtype": "wrong", "types": ["query_bot"] },
-        { "subtype": "warning", "types": ["unverified"] }
+        {
+          "subtype": "wrong",
+          "types": [
+            "query_bot"
+          ]
+        },
+        {
+          "subtype": "warning",
+          "types": [
+            "unverified"
+          ]
+        }
       ]
     },
     {
       "scope": "error",
-      "types": [{ "subtype": "MessageFormatError", "types": ["TETR.IO", "TOS", "TOP"] }]
+      "types": [
+        {
+          "subtype": "MessageFormatError",
+          "types": [
+            "TETR.IO",
+            "TOS",
+            "TOP",
+            "duration"
+          ]
+        },
+        {
+          "subtype": "RequestError",
+          "types": [
+            {
+              "subtype": "request",
+              "types": [
+                "api",
+                "cloudflare",
+                "response",
+                "transport",
+                "failover"
+              ]
+            },
+            {
+              "subtype": "TETR.IO",
+              "types": [
+                "leaderboard",
+                "user_info",
+                "summaries",
+                "league_history",
+                "records"
+              ]
+            },
+            {
+              "subtype": "TOS",
+              "types": [
+                "user_info"
+              ]
+            }
+          ]
+        }
+      ]
     },
-    { "scope": "template", "types": ["template_language"] },
+    {
+      "scope": "template",
+      "types": [
+        "template_language"
+      ]
+    },
     {
       "scope": "bind",
       "types": [
         "not_found",
         "no_account",
         "confirm_unbind",
+        "confirm_yes",
+        "confirm_no",
         "config_success",
         "verify_already",
         "verify_failed",
@@ -27,7 +85,11 @@
     },
     {
       "scope": "record",
-      "types": ["not_found", "blitz", "sprint"]
+      "types": [
+        "not_found",
+        "blitz",
+        "sprint"
+      ]
     },
     {
       "scope": "stats",
@@ -51,19 +113,555 @@
     },
     {
       "scope": "template_ui",
-      "types": ["invalid_tag", "update_success", "update_failed"]
+      "types": [
+        "invalid_tag",
+        "update_success",
+        "update_failed"
+      ]
     },
     {
       "scope": "help",
-      "types": ["usage"]
+      "types": [
+        "usage"
+      ]
     },
     {
       "scope": "prompt",
-      "types": ["io_check", "io_bind", "top_check", "top_bind", "tos_check", "tos_bind"]
+      "types": [
+        "io_check",
+        "io_bind",
+        "top_check",
+        "top_bind",
+        "tos_check",
+        "tos_bind"
+      ]
     },
     {
       "scope": "retry",
-      "types": ["message"]
+      "types": [
+        "message",
+        "screenshot"
+      ]
+    },
+    {
+      "scope": "command",
+      "types": [
+        {
+          "subtype": "root",
+          "types": [
+            "description",
+            "plugin_description",
+            "plugin_usage"
+          ]
+        },
+        {
+          "subtype": "tetrio",
+          "types": [
+            "description",
+            {
+              "subtype": "bind",
+              "types": [
+                "description",
+                {
+                  "subtype": "args",
+                  "types": [
+                    {
+                      "subtype": "account",
+                      "types": [
+                        "notice"
+                      ]
+                    }
+                  ]
+                },
+                "shortcut"
+              ]
+            },
+            {
+              "subtype": "config",
+              "types": [
+                "description",
+                {
+                  "subtype": "options",
+                  "types": [
+                    {
+                      "subtype": "default_template",
+                      "types": [
+                        "help",
+                        {
+                          "subtype": "args",
+                          "types": [
+                            {
+                              "subtype": "template",
+                              "types": [
+                                "notice"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "subtype": "default_compare",
+                      "types": [
+                        "help",
+                        {
+                          "subtype": "args",
+                          "types": [
+                            {
+                              "subtype": "compare",
+                              "types": [
+                                "notice"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "shortcut"
+              ]
+            },
+            {
+              "subtype": "list",
+              "types": [
+                "description",
+                {
+                  "subtype": "options",
+                  "types": [
+                    {
+                      "subtype": "max_tr",
+                      "types": [
+                        "help"
+                      ]
+                    },
+                    {
+                      "subtype": "min_tr",
+                      "types": [
+                        "help"
+                      ]
+                    },
+                    {
+                      "subtype": "limit",
+                      "types": [
+                        "help"
+                      ]
+                    },
+                    {
+                      "subtype": "country",
+                      "types": [
+                        "help"
+                      ]
+                    },
+                    {
+                      "subtype": "sort",
+                      "types": [
+                        "help",
+                        {
+                          "subtype": "args",
+                          "types": [
+                            {
+                              "subtype": "sort",
+                              "types": [
+                                "notice"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "subtype": "query",
+              "types": [
+                "description",
+                {
+                  "subtype": "args",
+                  "types": [
+                    {
+                      "subtype": "who",
+                      "types": [
+                        "notice"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "subtype": "options",
+                  "types": [
+                    {
+                      "subtype": "template",
+                      "types": [
+                        "help",
+                        {
+                          "subtype": "args",
+                          "types": [
+                            {
+                              "subtype": "template",
+                              "types": [
+                                "notice"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "subtype": "compare",
+                      "types": [
+                        "help",
+                        {
+                          "subtype": "args",
+                          "types": [
+                            {
+                              "subtype": "compare",
+                              "types": [
+                                "notice"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "shortcut"
+              ]
+            },
+            {
+              "subtype": "rank",
+              "types": [
+                "description",
+                {
+                  "subtype": "all",
+                  "types": [
+                    "description",
+                    {
+                      "subtype": "options",
+                      "types": [
+                        {
+                          "subtype": "template",
+                          "types": [
+                            "help",
+                            {
+                              "subtype": "args",
+                              "types": [
+                                {
+                                  "subtype": "template",
+                                  "types": [
+                                    "notice"
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "subtype": "detail",
+                  "types": [
+                    "description",
+                    {
+                      "subtype": "args",
+                      "types": [
+                        {
+                          "subtype": "rank",
+                          "types": [
+                            "notice"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "shortcut"
+              ]
+            },
+            {
+              "subtype": "record",
+              "types": [
+                {
+                  "subtype": "args",
+                  "types": [
+                    {
+                      "subtype": "who",
+                      "types": [
+                        "notice"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "subtype": "options",
+                  "types": [
+                    {
+                      "subtype": "type",
+                      "types": [
+                        "help",
+                        {
+                          "subtype": "args",
+                          "types": [
+                            {
+                              "subtype": "record_type",
+                              "types": [
+                                "notice"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "subtype": "index",
+                      "types": [
+                        "help",
+                        {
+                          "subtype": "args",
+                          "types": [
+                            {
+                              "subtype": "index",
+                              "types": [
+                                "notice"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "subtype": "shortcuts",
+                  "types": [
+                    "blitz",
+                    "sprint"
+                  ]
+                }
+              ]
+            },
+            {
+              "subtype": "unbind",
+              "types": [
+                "description",
+                "shortcut"
+              ]
+            },
+            {
+              "subtype": "verify",
+              "types": [
+                "description",
+                "shortcut"
+              ]
+            }
+          ]
+        },
+        {
+          "subtype": "top",
+          "types": [
+            "description",
+            {
+              "subtype": "bind",
+              "types": [
+                "description",
+                {
+                  "subtype": "args",
+                  "types": [
+                    {
+                      "subtype": "account",
+                      "types": [
+                        "notice"
+                      ]
+                    }
+                  ]
+                },
+                "shortcut"
+              ]
+            },
+            {
+              "subtype": "unbind",
+              "types": [
+                "description",
+                "shortcut"
+              ]
+            },
+            {
+              "subtype": "config",
+              "types": [
+                "description",
+                {
+                  "subtype": "options",
+                  "types": [
+                    {
+                      "subtype": "default_compare",
+                      "types": [
+                        "help",
+                        {
+                          "subtype": "args",
+                          "types": [
+                            {
+                              "subtype": "compare",
+                              "types": [
+                                "notice"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "shortcut"
+              ]
+            },
+            {
+              "subtype": "query",
+              "types": [
+                "description",
+                {
+                  "subtype": "args",
+                  "types": [
+                    {
+                      "subtype": "who",
+                      "types": [
+                        "notice"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "subtype": "options",
+                  "types": [
+                    {
+                      "subtype": "compare",
+                      "types": [
+                        "help",
+                        {
+                          "subtype": "args",
+                          "types": [
+                            {
+                              "subtype": "compare",
+                              "types": [
+                                "notice"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "shortcut"
+              ]
+            }
+          ]
+        },
+        {
+          "subtype": "tos",
+          "types": [
+            "description",
+            {
+              "subtype": "bind",
+              "types": [
+                "description",
+                {
+                  "subtype": "args",
+                  "types": [
+                    {
+                      "subtype": "account",
+                      "types": [
+                        "notice"
+                      ]
+                    }
+                  ]
+                },
+                "shortcut"
+              ]
+            },
+            {
+              "subtype": "unbind",
+              "types": [
+                "description",
+                "shortcut"
+              ]
+            },
+            {
+              "subtype": "config",
+              "types": [
+                "description",
+                {
+                  "subtype": "options",
+                  "types": [
+                    {
+                      "subtype": "default_compare",
+                      "types": [
+                        "help",
+                        {
+                          "subtype": "args",
+                          "types": [
+                            {
+                              "subtype": "compare",
+                              "types": [
+                                "notice"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "shortcut"
+              ]
+            },
+            {
+              "subtype": "query",
+              "types": [
+                "description",
+                {
+                  "subtype": "args",
+                  "types": [
+                    {
+                      "subtype": "who",
+                      "types": [
+                        "notice"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "subtype": "options",
+                  "types": [
+                    {
+                      "subtype": "compare",
+                      "types": [
+                        "help",
+                        {
+                          "subtype": "args",
+                          "types": [
+                            {
+                              "subtype": "compare",
+                              "types": [
+                                "notice"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "shortcut"
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/nonebot_plugin_tetris_stats/i18n/en-US.json
+++ b/nonebot_plugin_tetris_stats/i18n/en-US.json
@@ -10,7 +10,27 @@
     "MessageFormatError": {
       "TETR.IO": "Username/ID is invalid",
       "TOS": "Username/ID is invalid",
-      "TOP": "Username is invalid"
+      "TOP": "Username is invalid",
+      "duration": "Invalid duration format"
+    },
+    "RequestError": {
+      "request": {
+        "api": "API request failed",
+        "cloudflare": "Failed to bypass Cloudflare verification",
+        "response": "Request error code: {status_code} {reason}\n{body}",
+        "transport": "Request error\n{detail}",
+        "failover": "All addresses are unavailable\n{errors}"
+      },
+      "TETR.IO": {
+        "leaderboard": "Leaderboard request error:\n{detail}",
+        "user_info": "User information request error:\n{detail}",
+        "summaries": "User summaries request error:\n{detail}",
+        "league_history": "League history request error:\n{detail}",
+        "records": "User records request error:\n{detail}"
+      },
+      "TOS": {
+        "user_info": "User information request error:\n{detail}"
+      }
     }
   },
   "template": {
@@ -20,6 +40,8 @@
     "not_found": "No binding information found",
     "no_account": "You haven't bound a {game} account yet",
     "confirm_unbind": "Are you sure you want to unbind?",
+    "confirm_yes": "Yes",
+    "confirm_no": "No",
     "config_success": "Configuration successful",
     "verify_already": "You have already completed verification.",
     "verify_failed": "Verification failed. Please confirm the target {game} account is linked to your current Discord account.",
@@ -64,6 +86,172 @@
     "tos_bind": "tos bind {{gameID}}"
   },
   "retry": {
-    "message": "Retrying: {func} ({i}/{max_attempts})"
+    "message": "Retrying: {func} ({i}/{max_attempts})",
+    "screenshot": "Screenshot failed, retrying"
+  },
+  "command": {
+    "root": {
+      "description": "Query player data for Tetris-related games",
+      "plugin_description": "A plugin for querying player data from Tetris-related games",
+      "plugin_usage": "Send tstats --help for usage"
+    },
+    "tetrio": {
+      "description": "TETR.IO game commands",
+      "bind": {
+        "description": "Bind a TETR.IO account",
+        "args": { "account": { "notice": "TETR.IO username / ID" } },
+        "shortcut": "iobind"
+      },
+      "config": {
+        "description": "Configure TETR.IO queries",
+        "options": {
+          "default_template": {
+            "help": "Set the default query template",
+            "args": { "template": { "notice": "Template version" } }
+          },
+          "default_compare": {
+            "help": "Set the default comparison time span",
+            "args": { "compare": { "notice": "Comparison time span (e.g. 7d, 2w, 24h)" } }
+          }
+        },
+        "shortcut": "ioconfig"
+      },
+      "list": {
+        "description": "Query the TETR.IO ranked leaderboard",
+        "options": {
+          "max_tr": { "help": "Maximum TR" },
+          "min_tr": { "help": "Minimum TR" },
+          "limit": { "help": "Number of results" },
+          "country": { "help": "Country code" },
+          "sort": {
+            "help": "Ranking metric",
+            "args": { "sort": { "notice": "Ranking metric (league, pps, apm, adpm, apl, or adpl)" } }
+          }
+        }
+      },
+      "query": {
+        "description": "Query TETR.IO game information",
+        "args": { "who": { "notice": "@person to query / me / TETR.IO username / ID" } },
+        "options": {
+          "template": {
+            "help": "Select the query template",
+            "args": { "template": { "notice": "Template version" } }
+          },
+          "compare": {
+            "help": "Specify a comparison time span",
+            "args": { "compare": { "notice": "Comparison time span (e.g. 7d, 2w, 24h)" } }
+          }
+        },
+        "shortcut": "ioquery"
+      },
+      "rank": {
+        "description": "Query TETR.IO rank information",
+        "all": {
+          "description": "Query an overview of all ranks",
+          "options": {
+            "template": {
+              "help": "Select the query template",
+              "args": { "template": { "notice": "Template version" } }
+            }
+          }
+        },
+        "detail": {
+          "description": "Query details for a specific rank",
+          "args": { "rank": { "notice": "Rank name" } }
+        },
+        "shortcut": "iorank"
+      },
+      "record": {
+        "args": { "who": { "notice": "@person to query / me / TETR.IO username / ID" } },
+        "options": {
+          "type": {
+            "help": "Record type",
+            "args": { "record_type": { "notice": "Record type (top, recent, or progression)" } }
+          },
+          "index": {
+            "help": "Record index",
+            "args": { "index": { "notice": "Record index" } }
+          }
+        },
+        "shortcuts": {
+          "blitz": "iorecordblitz",
+          "sprint": "iorecord40l"
+        }
+      },
+      "unbind": {
+        "description": "Unbind the TETR.IO account",
+        "shortcut": "iounbind"
+      },
+      "verify": {
+        "description": "Verify the TETR.IO account",
+        "shortcut": "ioverify"
+      }
+    },
+    "top": {
+      "description": "TOP game commands",
+      "bind": {
+        "description": "Bind a TOP account",
+        "args": { "account": { "notice": "TOP username / ID" } },
+        "shortcut": "topbind"
+      },
+      "unbind": {
+        "description": "Unbind the TOP account",
+        "shortcut": "topunbind"
+      },
+      "config": {
+        "description": "Configure TOP queries",
+        "options": {
+          "default_compare": {
+            "help": "Set the default comparison time span",
+            "args": { "compare": { "notice": "Comparison time span (e.g. 7d, 2w, 24h)" } }
+          }
+        },
+        "shortcut": "topconfig"
+      },
+      "query": {
+        "description": "Query TOP game information",
+        "args": { "who": { "notice": "@person to query / me / TOP username" } },
+        "options": {
+          "compare": {
+            "help": "Specify a comparison time span",
+            "args": { "compare": { "notice": "Comparison time span (e.g. 7d, 2w, 24h)" } }
+          }
+        },
+        "shortcut": "topquery"
+      }
+    },
+    "tos": {
+      "description": "TOS game commands",
+      "bind": {
+        "description": "Bind a TOS account",
+        "args": { "account": { "notice": "TOS username / ID" } },
+        "shortcut": "tosbind"
+      },
+      "unbind": {
+        "description": "Unbind the TOS account",
+        "shortcut": "tosunbind"
+      },
+      "config": {
+        "description": "Configure TOS queries",
+        "options": {
+          "default_compare": {
+            "help": "Set the default comparison time span",
+            "args": { "compare": { "notice": "Comparison time span (e.g. 7d, 2w, 24h)" } }
+          }
+        },
+        "shortcut": "tosconfig"
+      },
+      "query": {
+        "description": "Query TOS game information",
+        "args": { "who": { "notice": "@person to query / me / TOS username / TeaID" } },
+        "options": {
+          "compare": {
+            "help": "Specify a comparison time span",
+            "args": { "compare": { "notice": "Comparison time span (e.g. 7d, 2w, 24h)" } }
+          }
+        },
+        "shortcut": "tosquery"
+      }
+    }
   }
 }

--- a/nonebot_plugin_tetris_stats/i18n/model.py
+++ b/nonebot_plugin_tetris_stats/i18n/model.py
@@ -21,10 +21,38 @@ class ErrorMessageformaterror:
     TETR_IO: LangItem = LangItem('error', 'MessageFormatError.TETR.IO')
     TOS: LangItem = LangItem('error', 'MessageFormatError.TOS')
     TOP: LangItem = LangItem('error', 'MessageFormatError.TOP')
+    duration: LangItem = LangItem('error', 'MessageFormatError.duration')
+
+
+class ErrorRequesterrorRequest:
+    api: LangItem = LangItem('error', 'RequestError.request.api')
+    cloudflare: LangItem = LangItem('error', 'RequestError.request.cloudflare')
+    response: LangItem = LangItem('error', 'RequestError.request.response')
+    transport: LangItem = LangItem('error', 'RequestError.request.transport')
+    failover: LangItem = LangItem('error', 'RequestError.request.failover')
+
+
+class ErrorRequesterrorTetrIo:
+    leaderboard: LangItem = LangItem('error', 'RequestError.TETR.IO.leaderboard')
+    user_info: LangItem = LangItem('error', 'RequestError.TETR.IO.user_info')
+    summaries: LangItem = LangItem('error', 'RequestError.TETR.IO.summaries')
+    league_history: LangItem = LangItem('error', 'RequestError.TETR.IO.league_history')
+    records: LangItem = LangItem('error', 'RequestError.TETR.IO.records')
+
+
+class ErrorRequesterrorTos:
+    user_info: LangItem = LangItem('error', 'RequestError.TOS.user_info')
+
+
+class ErrorRequesterror:
+    request = ErrorRequesterrorRequest
+    TETR_IO = ErrorRequesterrorTetrIo
+    TOS = ErrorRequesterrorTos
 
 
 class Error:
     MessageFormatError = ErrorMessageformaterror
+    RequestError = ErrorRequesterror
 
 
 class Template:
@@ -35,6 +63,8 @@ class Bind:
     not_found: LangItem = LangItem('bind', 'not_found')
     no_account: LangItem = LangItem('bind', 'no_account')
     confirm_unbind: LangItem = LangItem('bind', 'confirm_unbind')
+    confirm_yes: LangItem = LangItem('bind', 'confirm_yes')
+    confirm_no: LangItem = LangItem('bind', 'confirm_no')
     config_success: LangItem = LangItem('bind', 'config_success')
     verify_already: LangItem = LangItem('bind', 'verify_already')
     verify_failed: LangItem = LangItem('bind', 'verify_failed')
@@ -86,6 +116,437 @@ class Prompt:
 
 class Retry:
     message: LangItem = LangItem('retry', 'message')
+    screenshot: LangItem = LangItem('retry', 'screenshot')
+
+
+class CommandRoot:
+    description: LangItem = LangItem('command', 'root.description')
+    plugin_description: LangItem = LangItem('command', 'root.plugin_description')
+    plugin_usage: LangItem = LangItem('command', 'root.plugin_usage')
+
+
+class CommandTetrioBindArgsAccount:
+    notice: LangItem = LangItem('command', 'tetrio.bind.args.account.notice')
+
+
+class CommandTetrioBindArgs:
+    account = CommandTetrioBindArgsAccount
+
+
+class CommandTetrioBind:
+    description: LangItem = LangItem('command', 'tetrio.bind.description')
+    args = CommandTetrioBindArgs
+    shortcut: LangItem = LangItem('command', 'tetrio.bind.shortcut')
+
+
+class CommandTetrioConfigOptionsDefaultTemplateArgsTemplate:
+    notice: LangItem = LangItem('command', 'tetrio.config.options.default_template.args.template.notice')
+
+
+class CommandTetrioConfigOptionsDefaultTemplateArgs:
+    template = CommandTetrioConfigOptionsDefaultTemplateArgsTemplate
+
+
+class CommandTetrioConfigOptionsDefaultTemplate:
+    help: LangItem = LangItem('command', 'tetrio.config.options.default_template.help')
+    args = CommandTetrioConfigOptionsDefaultTemplateArgs
+
+
+class CommandTetrioConfigOptionsDefaultCompareArgsCompare:
+    notice: LangItem = LangItem('command', 'tetrio.config.options.default_compare.args.compare.notice')
+
+
+class CommandTetrioConfigOptionsDefaultCompareArgs:
+    compare = CommandTetrioConfigOptionsDefaultCompareArgsCompare
+
+
+class CommandTetrioConfigOptionsDefaultCompare:
+    help: LangItem = LangItem('command', 'tetrio.config.options.default_compare.help')
+    args = CommandTetrioConfigOptionsDefaultCompareArgs
+
+
+class CommandTetrioConfigOptions:
+    default_template = CommandTetrioConfigOptionsDefaultTemplate
+    default_compare = CommandTetrioConfigOptionsDefaultCompare
+
+
+class CommandTetrioConfig:
+    description: LangItem = LangItem('command', 'tetrio.config.description')
+    options = CommandTetrioConfigOptions
+    shortcut: LangItem = LangItem('command', 'tetrio.config.shortcut')
+
+
+class CommandTetrioListOptionsMaxTr:
+    help: LangItem = LangItem('command', 'tetrio.list.options.max_tr.help')
+
+
+class CommandTetrioListOptionsMinTr:
+    help: LangItem = LangItem('command', 'tetrio.list.options.min_tr.help')
+
+
+class CommandTetrioListOptionsLimit:
+    help: LangItem = LangItem('command', 'tetrio.list.options.limit.help')
+
+
+class CommandTetrioListOptionsCountry:
+    help: LangItem = LangItem('command', 'tetrio.list.options.country.help')
+
+
+class CommandTetrioListOptionsSortArgsSort:
+    notice: LangItem = LangItem('command', 'tetrio.list.options.sort.args.sort.notice')
+
+
+class CommandTetrioListOptionsSortArgs:
+    sort = CommandTetrioListOptionsSortArgsSort
+
+
+class CommandTetrioListOptionsSort:
+    help: LangItem = LangItem('command', 'tetrio.list.options.sort.help')
+    args = CommandTetrioListOptionsSortArgs
+
+
+class CommandTetrioListOptions:
+    max_tr = CommandTetrioListOptionsMaxTr
+    min_tr = CommandTetrioListOptionsMinTr
+    limit = CommandTetrioListOptionsLimit
+    country = CommandTetrioListOptionsCountry
+    sort = CommandTetrioListOptionsSort
+
+
+class CommandTetrioList:
+    description: LangItem = LangItem('command', 'tetrio.list.description')
+    options = CommandTetrioListOptions
+
+
+class CommandTetrioQueryArgsWho:
+    notice: LangItem = LangItem('command', 'tetrio.query.args.who.notice')
+
+
+class CommandTetrioQueryArgs:
+    who = CommandTetrioQueryArgsWho
+
+
+class CommandTetrioQueryOptionsTemplateArgsTemplate:
+    notice: LangItem = LangItem('command', 'tetrio.query.options.template.args.template.notice')
+
+
+class CommandTetrioQueryOptionsTemplateArgs:
+    template = CommandTetrioQueryOptionsTemplateArgsTemplate
+
+
+class CommandTetrioQueryOptionsTemplate:
+    help: LangItem = LangItem('command', 'tetrio.query.options.template.help')
+    args = CommandTetrioQueryOptionsTemplateArgs
+
+
+class CommandTetrioQueryOptionsCompareArgsCompare:
+    notice: LangItem = LangItem('command', 'tetrio.query.options.compare.args.compare.notice')
+
+
+class CommandTetrioQueryOptionsCompareArgs:
+    compare = CommandTetrioQueryOptionsCompareArgsCompare
+
+
+class CommandTetrioQueryOptionsCompare:
+    help: LangItem = LangItem('command', 'tetrio.query.options.compare.help')
+    args = CommandTetrioQueryOptionsCompareArgs
+
+
+class CommandTetrioQueryOptions:
+    template = CommandTetrioQueryOptionsTemplate
+    compare = CommandTetrioQueryOptionsCompare
+
+
+class CommandTetrioQuery:
+    description: LangItem = LangItem('command', 'tetrio.query.description')
+    args = CommandTetrioQueryArgs
+    options = CommandTetrioQueryOptions
+    shortcut: LangItem = LangItem('command', 'tetrio.query.shortcut')
+
+
+class CommandTetrioRankAllOptionsTemplateArgsTemplate:
+    notice: LangItem = LangItem('command', 'tetrio.rank.all.options.template.args.template.notice')
+
+
+class CommandTetrioRankAllOptionsTemplateArgs:
+    template = CommandTetrioRankAllOptionsTemplateArgsTemplate
+
+
+class CommandTetrioRankAllOptionsTemplate:
+    help: LangItem = LangItem('command', 'tetrio.rank.all.options.template.help')
+    args = CommandTetrioRankAllOptionsTemplateArgs
+
+
+class CommandTetrioRankAllOptions:
+    template = CommandTetrioRankAllOptionsTemplate
+
+
+class CommandTetrioRankAll:
+    description: LangItem = LangItem('command', 'tetrio.rank.all.description')
+    options = CommandTetrioRankAllOptions
+
+
+class CommandTetrioRankDetailArgsRank:
+    notice: LangItem = LangItem('command', 'tetrio.rank.detail.args.rank.notice')
+
+
+class CommandTetrioRankDetailArgs:
+    rank = CommandTetrioRankDetailArgsRank
+
+
+class CommandTetrioRankDetail:
+    description: LangItem = LangItem('command', 'tetrio.rank.detail.description')
+    args = CommandTetrioRankDetailArgs
+
+
+class CommandTetrioRank:
+    description: LangItem = LangItem('command', 'tetrio.rank.description')
+    all = CommandTetrioRankAll
+    detail = CommandTetrioRankDetail
+    shortcut: LangItem = LangItem('command', 'tetrio.rank.shortcut')
+
+
+class CommandTetrioRecordArgsWho:
+    notice: LangItem = LangItem('command', 'tetrio.record.args.who.notice')
+
+
+class CommandTetrioRecordArgs:
+    who = CommandTetrioRecordArgsWho
+
+
+class CommandTetrioRecordOptionsTypeArgsRecordType:
+    notice: LangItem = LangItem('command', 'tetrio.record.options.type.args.record_type.notice')
+
+
+class CommandTetrioRecordOptionsTypeArgs:
+    record_type = CommandTetrioRecordOptionsTypeArgsRecordType
+
+
+class CommandTetrioRecordOptionsType:
+    help: LangItem = LangItem('command', 'tetrio.record.options.type.help')
+    args = CommandTetrioRecordOptionsTypeArgs
+
+
+class CommandTetrioRecordOptionsIndexArgsIndex:
+    notice: LangItem = LangItem('command', 'tetrio.record.options.index.args.index.notice')
+
+
+class CommandTetrioRecordOptionsIndexArgs:
+    index = CommandTetrioRecordOptionsIndexArgsIndex
+
+
+class CommandTetrioRecordOptionsIndex:
+    help: LangItem = LangItem('command', 'tetrio.record.options.index.help')
+    args = CommandTetrioRecordOptionsIndexArgs
+
+
+class CommandTetrioRecordOptions:
+    type = CommandTetrioRecordOptionsType
+    index = CommandTetrioRecordOptionsIndex
+
+
+class CommandTetrioRecordShortcuts:
+    blitz: LangItem = LangItem('command', 'tetrio.record.shortcuts.blitz')
+    sprint: LangItem = LangItem('command', 'tetrio.record.shortcuts.sprint')
+
+
+class CommandTetrioRecord:
+    args = CommandTetrioRecordArgs
+    options = CommandTetrioRecordOptions
+    shortcuts = CommandTetrioRecordShortcuts
+
+
+class CommandTetrioUnbind:
+    description: LangItem = LangItem('command', 'tetrio.unbind.description')
+    shortcut: LangItem = LangItem('command', 'tetrio.unbind.shortcut')
+
+
+class CommandTetrioVerify:
+    description: LangItem = LangItem('command', 'tetrio.verify.description')
+    shortcut: LangItem = LangItem('command', 'tetrio.verify.shortcut')
+
+
+class CommandTetrio:
+    description: LangItem = LangItem('command', 'tetrio.description')
+    bind = CommandTetrioBind
+    config = CommandTetrioConfig
+    list = CommandTetrioList
+    query = CommandTetrioQuery
+    rank = CommandTetrioRank
+    record = CommandTetrioRecord
+    unbind = CommandTetrioUnbind
+    verify = CommandTetrioVerify
+
+
+class CommandTopBindArgsAccount:
+    notice: LangItem = LangItem('command', 'top.bind.args.account.notice')
+
+
+class CommandTopBindArgs:
+    account = CommandTopBindArgsAccount
+
+
+class CommandTopBind:
+    description: LangItem = LangItem('command', 'top.bind.description')
+    args = CommandTopBindArgs
+    shortcut: LangItem = LangItem('command', 'top.bind.shortcut')
+
+
+class CommandTopUnbind:
+    description: LangItem = LangItem('command', 'top.unbind.description')
+    shortcut: LangItem = LangItem('command', 'top.unbind.shortcut')
+
+
+class CommandTopConfigOptionsDefaultCompareArgsCompare:
+    notice: LangItem = LangItem('command', 'top.config.options.default_compare.args.compare.notice')
+
+
+class CommandTopConfigOptionsDefaultCompareArgs:
+    compare = CommandTopConfigOptionsDefaultCompareArgsCompare
+
+
+class CommandTopConfigOptionsDefaultCompare:
+    help: LangItem = LangItem('command', 'top.config.options.default_compare.help')
+    args = CommandTopConfigOptionsDefaultCompareArgs
+
+
+class CommandTopConfigOptions:
+    default_compare = CommandTopConfigOptionsDefaultCompare
+
+
+class CommandTopConfig:
+    description: LangItem = LangItem('command', 'top.config.description')
+    options = CommandTopConfigOptions
+    shortcut: LangItem = LangItem('command', 'top.config.shortcut')
+
+
+class CommandTopQueryArgsWho:
+    notice: LangItem = LangItem('command', 'top.query.args.who.notice')
+
+
+class CommandTopQueryArgs:
+    who = CommandTopQueryArgsWho
+
+
+class CommandTopQueryOptionsCompareArgsCompare:
+    notice: LangItem = LangItem('command', 'top.query.options.compare.args.compare.notice')
+
+
+class CommandTopQueryOptionsCompareArgs:
+    compare = CommandTopQueryOptionsCompareArgsCompare
+
+
+class CommandTopQueryOptionsCompare:
+    help: LangItem = LangItem('command', 'top.query.options.compare.help')
+    args = CommandTopQueryOptionsCompareArgs
+
+
+class CommandTopQueryOptions:
+    compare = CommandTopQueryOptionsCompare
+
+
+class CommandTopQuery:
+    description: LangItem = LangItem('command', 'top.query.description')
+    args = CommandTopQueryArgs
+    options = CommandTopQueryOptions
+    shortcut: LangItem = LangItem('command', 'top.query.shortcut')
+
+
+class CommandTop:
+    description: LangItem = LangItem('command', 'top.description')
+    bind = CommandTopBind
+    unbind = CommandTopUnbind
+    config = CommandTopConfig
+    query = CommandTopQuery
+
+
+class CommandTosBindArgsAccount:
+    notice: LangItem = LangItem('command', 'tos.bind.args.account.notice')
+
+
+class CommandTosBindArgs:
+    account = CommandTosBindArgsAccount
+
+
+class CommandTosBind:
+    description: LangItem = LangItem('command', 'tos.bind.description')
+    args = CommandTosBindArgs
+    shortcut: LangItem = LangItem('command', 'tos.bind.shortcut')
+
+
+class CommandTosUnbind:
+    description: LangItem = LangItem('command', 'tos.unbind.description')
+    shortcut: LangItem = LangItem('command', 'tos.unbind.shortcut')
+
+
+class CommandTosConfigOptionsDefaultCompareArgsCompare:
+    notice: LangItem = LangItem('command', 'tos.config.options.default_compare.args.compare.notice')
+
+
+class CommandTosConfigOptionsDefaultCompareArgs:
+    compare = CommandTosConfigOptionsDefaultCompareArgsCompare
+
+
+class CommandTosConfigOptionsDefaultCompare:
+    help: LangItem = LangItem('command', 'tos.config.options.default_compare.help')
+    args = CommandTosConfigOptionsDefaultCompareArgs
+
+
+class CommandTosConfigOptions:
+    default_compare = CommandTosConfigOptionsDefaultCompare
+
+
+class CommandTosConfig:
+    description: LangItem = LangItem('command', 'tos.config.description')
+    options = CommandTosConfigOptions
+    shortcut: LangItem = LangItem('command', 'tos.config.shortcut')
+
+
+class CommandTosQueryArgsWho:
+    notice: LangItem = LangItem('command', 'tos.query.args.who.notice')
+
+
+class CommandTosQueryArgs:
+    who = CommandTosQueryArgsWho
+
+
+class CommandTosQueryOptionsCompareArgsCompare:
+    notice: LangItem = LangItem('command', 'tos.query.options.compare.args.compare.notice')
+
+
+class CommandTosQueryOptionsCompareArgs:
+    compare = CommandTosQueryOptionsCompareArgsCompare
+
+
+class CommandTosQueryOptionsCompare:
+    help: LangItem = LangItem('command', 'tos.query.options.compare.help')
+    args = CommandTosQueryOptionsCompareArgs
+
+
+class CommandTosQueryOptions:
+    compare = CommandTosQueryOptionsCompare
+
+
+class CommandTosQuery:
+    description: LangItem = LangItem('command', 'tos.query.description')
+    args = CommandTosQueryArgs
+    options = CommandTosQueryOptions
+    shortcut: LangItem = LangItem('command', 'tos.query.shortcut')
+
+
+class CommandTos:
+    description: LangItem = LangItem('command', 'tos.description')
+    bind = CommandTosBind
+    unbind = CommandTosUnbind
+    config = CommandTosConfig
+    query = CommandTosQuery
+
+
+class Command:
+    root = CommandRoot
+    tetrio = CommandTetrio
+    top = CommandTop
+    tos = CommandTos
 
 
 class Lang(LangModel):
@@ -99,3 +560,4 @@ class Lang(LangModel):
     help = Help
     prompt = Prompt
     retry = Retry
+    command = Command

--- a/nonebot_plugin_tetris_stats/i18n/zh-CN.json
+++ b/nonebot_plugin_tetris_stats/i18n/zh-CN.json
@@ -8,7 +8,27 @@
     "MessageFormatError": {
       "TETR.IO": "用户名/ID不合法",
       "TOS": "用户名/ID不合法",
-      "TOP": "用户名不合法"
+      "TOP": "用户名不合法",
+      "duration": "时间格式不正确"
+    },
+    "RequestError": {
+      "request": {
+        "api": "API 请求失败",
+        "cloudflare": "绕过 Cloudflare 验证失败",
+        "response": "请求错误 code: {status_code} {reason}\n{body}",
+        "transport": "请求错误\n{detail}",
+        "failover": "所有地址皆不可用\n{errors}"
+      },
+      "TETR.IO": {
+        "leaderboard": "排行榜信息请求错误:\n{detail}",
+        "user_info": "用户信息请求错误:\n{detail}",
+        "summaries": "用户 Summaries 数据请求错误:\n{detail}",
+        "league_history": "League 历史记录请求错误:\n{detail}",
+        "records": "用户 Records 数据请求错误:\n{detail}"
+      },
+      "TOS": {
+        "user_info": "用户信息请求错误:\n{detail}"
+      }
     }
   },
   "template": {
@@ -18,6 +38,8 @@
     "not_found": "未查询到绑定信息",
     "no_account": "您还未绑定 {game} 账号",
     "confirm_unbind": "您确定要解绑吗?",
+    "confirm_yes": "是",
+    "confirm_no": "否",
     "config_success": "配置成功",
     "verify_already": "您已经完成了验证.",
     "verify_failed": "您未通过验证, 请确认目标 {game} 账号绑定了当前 Discord 账号",
@@ -62,6 +84,172 @@
     "tos_bind": "茶服绑定{{游戏ID}}"
   },
   "retry": {
-    "message": "Retrying: {func} ({i}/{max_attempts})"
+    "message": "正在重试：{func}（{i}/{max_attempts}）",
+    "screenshot": "截图失败，正在重试"
+  },
+  "command": {
+    "root": {
+      "description": "俄罗斯方块相关游戏数据查询",
+      "plugin_description": "一个用于查询 Tetris 相关游戏玩家数据的插件",
+      "plugin_usage": "发送 tstats --help 查询使用方法"
+    },
+    "tetrio": {
+      "description": "TETR.IO 游戏相关指令",
+      "bind": {
+        "description": "绑定 TETR.IO 账号",
+        "args": { "account": { "notice": "TETR.IO 用户名 / ID" } },
+        "shortcut": "io绑定"
+      },
+      "config": {
+        "description": "TETR.IO 查询个性化配置",
+        "options": {
+          "default_template": {
+            "help": "设置默认查询模板",
+            "args": { "template": { "notice": "模板版本" } }
+          },
+          "default_compare": {
+            "help": "设置默认对比时间距离",
+            "args": { "compare": { "notice": "对比时间距离 (如 7d, 2w, 24h)" } }
+          }
+        },
+        "shortcut": "io配置"
+      },
+      "list": {
+        "description": "查询 TETR.IO 段位排行榜",
+        "options": {
+          "max_tr": { "help": "TR的上限" },
+          "min_tr": { "help": "TR的下限" },
+          "limit": { "help": "查询数量" },
+          "country": { "help": "国家代码" },
+          "sort": {
+            "help": "排名指标",
+            "args": { "sort": { "notice": "排名指标 (league、pps、apm、adpm、apl 或 adpl)" } }
+          }
+        }
+      },
+      "query": {
+        "description": "查询 TETR.IO 游戏信息",
+        "args": { "who": { "notice": "@想要查询的人 / 自己 / TETR.IO 用户名 / ID" } },
+        "options": {
+          "template": {
+            "help": "要使用的查询模板",
+            "args": { "template": { "notice": "模板版本" } }
+          },
+          "compare": {
+            "help": "指定对比时间距离",
+            "args": { "compare": { "notice": "对比时间距离 (如 7d, 2w, 24h)" } }
+          }
+        },
+        "shortcut": "io查"
+      },
+      "rank": {
+        "description": "查询 TETR.IO 段位信息",
+        "all": {
+          "description": "查询所有段位概览",
+          "options": {
+            "template": {
+              "help": "要使用的查询模板",
+              "args": { "template": { "notice": "模板版本" } }
+            }
+          }
+        },
+        "detail": {
+          "description": "查询指定段位的详细信息",
+          "args": { "rank": { "notice": "段位名" } }
+        },
+        "shortcut": "iorank"
+      },
+      "record": {
+        "args": { "who": { "notice": "@想要查询的人 / 自己 / TETR.IO 用户名 / ID" } },
+        "options": {
+          "type": {
+            "help": "记录类型",
+            "args": { "record_type": { "notice": "记录类型 (top、recent、progression)" } }
+          },
+          "index": {
+            "help": "记录序号",
+            "args": { "index": { "notice": "记录序号" } }
+          }
+        },
+        "shortcuts": {
+          "blitz": "io记录blitz",
+          "sprint": "io记录40l"
+        }
+      },
+      "unbind": {
+        "description": "解除绑定 TETR.IO 账号",
+        "shortcut": "io解绑"
+      },
+      "verify": {
+        "description": "验证 TETR.IO 账号",
+        "shortcut": "io验证"
+      }
+    },
+    "top": {
+      "description": "TOP 游戏相关指令",
+      "bind": {
+        "description": "绑定 TOP 账号",
+        "args": { "account": { "notice": "TOP 用户名 / ID" } },
+        "shortcut": "top绑定"
+      },
+      "unbind": {
+        "description": "解除绑定 TOP 账号",
+        "shortcut": "top解绑"
+      },
+      "config": {
+        "description": "TOP 查询个性化配置",
+        "options": {
+          "default_compare": {
+            "help": "设置默认对比时间距离",
+            "args": { "compare": { "notice": "对比时间距离 (如 7d, 2w, 24h)" } }
+          }
+        },
+        "shortcut": "top配置"
+      },
+      "query": {
+        "description": "查询 TOP 游戏信息",
+        "args": { "who": { "notice": "@想要查询的人 / 自己 / TOP 用户名" } },
+        "options": {
+          "compare": {
+            "help": "指定对比时间距离",
+            "args": { "compare": { "notice": "对比时间距离 (如 7d, 2w, 24h)" } }
+          }
+        },
+        "shortcut": "top查"
+      }
+    },
+    "tos": {
+      "description": "茶服 游戏相关指令",
+      "bind": {
+        "description": "绑定 茶服 账号",
+        "args": { "account": { "notice": "茶服 用户名 / ID" } },
+        "shortcut": "茶服绑定"
+      },
+      "unbind": {
+        "description": "解除绑定 TOS 账号",
+        "shortcut": "茶服解绑"
+      },
+      "config": {
+        "description": "茶服 查询个性化配置",
+        "options": {
+          "default_compare": {
+            "help": "设置默认对比时间距离",
+            "args": { "compare": { "notice": "对比时间距离 (如 7d, 2w, 24h)" } }
+          }
+        },
+        "shortcut": "茶服配置"
+      },
+      "query": {
+        "description": "查询 茶服 游戏信息",
+        "args": { "who": { "notice": "@想要查询的人 / 自己 / 茶服 用户名 / TeaID" } },
+        "options": {
+          "compare": {
+            "help": "指定对比时间距离",
+            "args": { "compare": { "notice": "对比时间距离 (如 7d, 2w, 24h)" } }
+          }
+        },
+        "shortcut": "茶服查"
+      }
+    }
   }
 }

--- a/nonebot_plugin_tetris_stats/utils/duration.py
+++ b/nonebot_plugin_tetris_stats/utils/duration.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+from ..i18n import Lang
 from .exception import MessageFormatError
 
 DEFAULT_COMPARE_DELTA = timedelta(days=7)
@@ -18,11 +19,11 @@ def parse_duration(value: str) -> timedelta | MessageFormatError:
     if raw.isdigit():
         return timedelta(days=int(raw))
     if len(raw) < _MIN_DURATION_LEN or not raw[:-1].isdigit():
-        return MessageFormatError('时间格式不正确')
+        return MessageFormatError(Lang.error.MessageFormatError.duration)
     amount = int(raw[:-1])
     if amount <= 0:
-        return MessageFormatError('时间格式不正确')
+        return MessageFormatError(Lang.error.MessageFormatError.duration)
     unit = _DURATION_UNITS.get(raw[-1])
     if unit is None:
-        return MessageFormatError('时间格式不正确')
+        return MessageFormatError(Lang.error.MessageFormatError.duration)
     return timedelta(**{unit: amount})

--- a/nonebot_plugin_tetris_stats/utils/exception.py
+++ b/nonebot_plugin_tetris_stats/utils/exception.py
@@ -1,19 +1,32 @@
+from tarina.lang.model import LangItem
 from typing_extensions import override
 
 
 class TetrisStatsError(Exception):
     """所有 TetrisStats 发生的异常基类"""
 
-    def __init__(self, message: str = ''):
-        self.message = message
+    def __init__(self, message: str | LangItem = '', **format_kwargs: object):
+        self._message = message
+        self._format_kwargs = format_kwargs
+
+    @property
+    def message(self) -> str:
+        return self.render()
+
+    def render(self, locale: str | None = None) -> str:
+        if isinstance(self._message, LangItem):
+            return self._message(locale, **self._format_kwargs)
+        if self._format_kwargs:
+            return self._message.format(**self._format_kwargs)
+        return self._message
 
     @override
     def __str__(self) -> str:
-        return self.message
+        return self.render()
 
     @override
     def __repr__(self) -> str:
-        return self.message
+        return self.render()
 
 
 class NeedCatchError(TetrisStatsError):
@@ -23,8 +36,16 @@ class NeedCatchError(TetrisStatsError):
 class RequestError(NeedCatchError):
     """请求错误"""
 
-    def __init__(self, message: str = '', *, status_code: int | None = None):
-        super().__init__(message)
+    def __init__(
+        self,
+        message: str | LangItem = '',
+        *,
+        status_code: int | None = None,
+        **format_kwargs: object,
+    ):
+        if status_code is not None:
+            format_kwargs.setdefault('status_code', status_code)
+        super().__init__(message, **format_kwargs)
         self.status_code = status_code
 
 

--- a/nonebot_plugin_tetris_stats/utils/help_catalog.py
+++ b/nonebot_plugin_tetris_stats/utils/help_catalog.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 Breadcrumb = tuple[str, ...]
 FieldKind = Literal['description', 'arg', 'option', 'option_arg']
-Locale = Literal['zh-CN', 'en-US']
+Locale = Literal['zh-CN', 'zh-TW', 'en-US', 'es-ES', 'ja-JP', 'ko-KR']
 
 
 @dataclass(frozen=True)

--- a/nonebot_plugin_tetris_stats/utils/help_catalog.py
+++ b/nonebot_plugin_tetris_stats/utils/help_catalog.py
@@ -1,0 +1,332 @@
+"""Request-local command help translations.
+
+The Alconna command tree is process-global and intentionally keeps its static
+Chinese metadata.  This module overlays a newly-built ``HelpData`` value for
+one explicit locale; it never reads or mutates the shared command tree.
+"""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Literal
+
+from tarina.lang.model import LangItem
+
+from ..i18n import Lang
+
+if TYPE_CHECKING:
+    from .render.schemas.help import HelpArg, HelpData, HelpNode, HelpOption, HelpShortcut
+
+Breadcrumb = tuple[str, ...]
+FieldKind = Literal['description', 'arg', 'option', 'option_arg']
+Locale = Literal['zh-CN', 'en-US']
+
+
+@dataclass(frozen=True)
+class _FieldIdentity:
+    breadcrumb: Breadcrumb
+    kind: FieldKind
+    name: str = ''
+    arg_name: str = ''
+
+
+@dataclass(frozen=True)
+class _ShortcutIdentity:
+    target: Breadcrumb
+    humanized: str
+
+
+_ROOT = 'tetris-stats'
+_TETRIO = (_ROOT, 'TETR.IO')
+_TOP = (_ROOT, 'TOP')
+_TOS = (_ROOT, 'TOS')
+
+# Canonical Alconna breadcrumbs and field identities are the catalog keys.
+# Entries for not-yet-present fields are harmless: traversal only visits
+# nodes/arguments/options that exist in the HelpData being localized.
+_FIELDS: Mapping[_FieldIdentity, LangItem] = MappingProxyType(
+    {
+        _FieldIdentity((_ROOT,), 'description'): Lang.command.root.description,
+        _FieldIdentity(_TETRIO, 'description'): Lang.command.tetrio.description,
+        _FieldIdentity((*_TETRIO, 'bind'), 'description'): Lang.command.tetrio.bind.description,
+        _FieldIdentity((*_TETRIO, 'bind'), 'arg', 'account'): Lang.command.tetrio.bind.args.account.notice,
+        _FieldIdentity((*_TETRIO, 'config'), 'description'): Lang.command.tetrio.config.description,
+        _FieldIdentity(
+            (*_TETRIO, 'config'), 'option', '--default-template'
+        ): Lang.command.tetrio.config.options.default_template.help,
+        _FieldIdentity(
+            (*_TETRIO, 'config'), 'option_arg', '--default-template', 'template'
+        ): Lang.command.tetrio.config.options.default_template.args.template.notice,
+        _FieldIdentity(
+            (*_TETRIO, 'config'), 'option', '--default-compare'
+        ): Lang.command.tetrio.config.options.default_compare.help,
+        _FieldIdentity(
+            (*_TETRIO, 'config'), 'option_arg', '--default-compare', 'compare'
+        ): Lang.command.tetrio.config.options.default_compare.args.compare.notice,
+        _FieldIdentity((*_TETRIO, 'list'), 'description'): Lang.command.tetrio.list.description,
+        _FieldIdentity((*_TETRIO, 'list'), 'option', '--max-tr'): Lang.command.tetrio.list.options.max_tr.help,
+        _FieldIdentity((*_TETRIO, 'list'), 'option', '--min-tr'): Lang.command.tetrio.list.options.min_tr.help,
+        _FieldIdentity((*_TETRIO, 'list'), 'option', '--limit'): Lang.command.tetrio.list.options.limit.help,
+        _FieldIdentity((*_TETRIO, 'list'), 'option', '--country'): Lang.command.tetrio.list.options.country.help,
+        # Pre-seeded for #452. No matching option means no output change.
+        _FieldIdentity((*_TETRIO, 'list'), 'option', '--sort'): Lang.command.tetrio.list.options.sort.help,
+        _FieldIdentity(
+            (*_TETRIO, 'list'), 'option_arg', '--sort', 'sort'
+        ): Lang.command.tetrio.list.options.sort.args.sort.notice,
+        _FieldIdentity((*_TETRIO, 'query'), 'description'): Lang.command.tetrio.query.description,
+        _FieldIdentity((*_TETRIO, 'query'), 'arg', 'who'): Lang.command.tetrio.query.args.who.notice,
+        _FieldIdentity((*_TETRIO, 'query'), 'option', '--template'): Lang.command.tetrio.query.options.template.help,
+        _FieldIdentity(
+            (*_TETRIO, 'query'), 'option_arg', '--template', 'template'
+        ): Lang.command.tetrio.query.options.template.args.template.notice,
+        _FieldIdentity((*_TETRIO, 'query'), 'option', '--compare'): Lang.command.tetrio.query.options.compare.help,
+        _FieldIdentity(
+            (*_TETRIO, 'query'), 'option_arg', '--compare', 'compare'
+        ): Lang.command.tetrio.query.options.compare.args.compare.notice,
+        _FieldIdentity((*_TETRIO, 'rank'), 'description'): Lang.command.tetrio.rank.description,
+        _FieldIdentity((*_TETRIO, 'rank', '--all'), 'description'): Lang.command.tetrio.rank.all.description,
+        _FieldIdentity(
+            (*_TETRIO, 'rank', '--all'), 'option', '--template'
+        ): Lang.command.tetrio.rank.all.options.template.help,
+        _FieldIdentity(
+            (*_TETRIO, 'rank', '--all'), 'option_arg', '--template', 'template'
+        ): Lang.command.tetrio.rank.all.options.template.args.template.notice,
+        _FieldIdentity((*_TETRIO, 'rank', '--detail'), 'description'): Lang.command.tetrio.rank.detail.description,
+        _FieldIdentity((*_TETRIO, 'rank', '--detail'), 'arg', 'rank'): Lang.command.tetrio.rank.detail.args.rank.notice,
+        _FieldIdentity((*_TETRIO, 'record'), 'arg', 'who'): Lang.command.tetrio.record.args.who.notice,
+        # Pre-seeded for #345. Missing options/arguments are ignored.
+        _FieldIdentity((*_TETRIO, 'record'), 'option', '--type'): Lang.command.tetrio.record.options.type.help,
+        _FieldIdentity(
+            (*_TETRIO, 'record'), 'option_arg', '--type', 'record_type'
+        ): Lang.command.tetrio.record.options.type.args.record_type.notice,
+        _FieldIdentity((*_TETRIO, 'record'), 'option', '--index'): Lang.command.tetrio.record.options.index.help,
+        _FieldIdentity(
+            (*_TETRIO, 'record'), 'option_arg', '--index', 'index'
+        ): Lang.command.tetrio.record.options.index.args.index.notice,
+        _FieldIdentity((*_TETRIO, 'unbind'), 'description'): Lang.command.tetrio.unbind.description,
+        _FieldIdentity((*_TETRIO, 'verify'), 'description'): Lang.command.tetrio.verify.description,
+        _FieldIdentity(_TOP, 'description'): Lang.command.top.description,
+        _FieldIdentity((*_TOP, 'bind'), 'description'): Lang.command.top.bind.description,
+        _FieldIdentity((*_TOP, 'bind'), 'arg', 'account'): Lang.command.top.bind.args.account.notice,
+        _FieldIdentity((*_TOP, 'unbind'), 'description'): Lang.command.top.unbind.description,
+        _FieldIdentity((*_TOP, 'config'), 'description'): Lang.command.top.config.description,
+        _FieldIdentity(
+            (*_TOP, 'config'), 'option', '--default-compare'
+        ): Lang.command.top.config.options.default_compare.help,
+        _FieldIdentity(
+            (*_TOP, 'config'), 'option_arg', '--default-compare', 'compare'
+        ): Lang.command.top.config.options.default_compare.args.compare.notice,
+        _FieldIdentity((*_TOP, 'query'), 'description'): Lang.command.top.query.description,
+        _FieldIdentity((*_TOP, 'query'), 'arg', 'who'): Lang.command.top.query.args.who.notice,
+        _FieldIdentity((*_TOP, 'query'), 'option', '--compare'): Lang.command.top.query.options.compare.help,
+        _FieldIdentity(
+            (*_TOP, 'query'), 'option_arg', '--compare', 'compare'
+        ): Lang.command.top.query.options.compare.args.compare.notice,
+        _FieldIdentity(_TOS, 'description'): Lang.command.tos.description,
+        _FieldIdentity((*_TOS, 'bind'), 'description'): Lang.command.tos.bind.description,
+        _FieldIdentity((*_TOS, 'bind'), 'arg', 'account'): Lang.command.tos.bind.args.account.notice,
+        _FieldIdentity((*_TOS, 'unbind'), 'description'): Lang.command.tos.unbind.description,
+        _FieldIdentity((*_TOS, 'config'), 'description'): Lang.command.tos.config.description,
+        _FieldIdentity(
+            (*_TOS, 'config'), 'option', '--default-compare'
+        ): Lang.command.tos.config.options.default_compare.help,
+        _FieldIdentity(
+            (*_TOS, 'config'), 'option_arg', '--default-compare', 'compare'
+        ): Lang.command.tos.config.options.default_compare.args.compare.notice,
+        _FieldIdentity((*_TOS, 'query'), 'description'): Lang.command.tos.query.description,
+        _FieldIdentity((*_TOS, 'query'), 'arg', 'who'): Lang.command.tos.query.args.who.notice,
+        _FieldIdentity((*_TOS, 'query'), 'option', '--compare'): Lang.command.tos.query.options.compare.help,
+        _FieldIdentity(
+            (*_TOS, 'query'), 'option_arg', '--compare', 'compare'
+        ): Lang.command.tos.query.options.compare.args.compare.notice,
+    }
+)
+
+# These production fields are intentional parser labels rather than user-facing
+# prose. They remain untranslated, but every fallback is explicit here.
+_FALLBACK_FIELDS = frozenset(
+    {
+        _FieldIdentity((*_TETRIO, 'record'), 'description'),
+        _FieldIdentity((*_TETRIO, 'record'), 'option', '--blitz'),
+        _FieldIdentity((*_TETRIO, 'record'), 'option', '--40l'),
+    }
+)
+
+_SHORTCUTS: Mapping[_ShortcutIdentity, LangItem] = MappingProxyType(
+    {
+        _ShortcutIdentity((*_TETRIO, 'bind'), 'io绑定'): Lang.command.tetrio.bind.shortcut,
+        _ShortcutIdentity((*_TETRIO, 'config'), 'io配置'): Lang.command.tetrio.config.shortcut,
+        _ShortcutIdentity((*_TETRIO, 'query'), 'io查'): Lang.command.tetrio.query.shortcut,
+        _ShortcutIdentity((*_TETRIO, 'rank'), 'iorank'): Lang.command.tetrio.rank.shortcut,
+        _ShortcutIdentity((*_TETRIO, 'record'), 'io记录blitz'): Lang.command.tetrio.record.shortcuts.blitz,
+        _ShortcutIdentity((*_TETRIO, 'record'), 'io记录40l'): Lang.command.tetrio.record.shortcuts.sprint,
+        _ShortcutIdentity((*_TETRIO, 'unbind'), 'io解绑'): Lang.command.tetrio.unbind.shortcut,
+        _ShortcutIdentity((*_TETRIO, 'verify'), 'io验证'): Lang.command.tetrio.verify.shortcut,
+        _ShortcutIdentity((*_TOP, 'bind'), 'top绑定'): Lang.command.top.bind.shortcut,
+        _ShortcutIdentity((*_TOP, 'unbind'), 'top解绑'): Lang.command.top.unbind.shortcut,
+        _ShortcutIdentity((*_TOP, 'query'), 'top查'): Lang.command.top.query.shortcut,
+        _ShortcutIdentity((*_TOP, 'config'), 'top配置'): Lang.command.top.config.shortcut,
+        _ShortcutIdentity((*_TOS, 'bind'), '茶服绑定'): Lang.command.tos.bind.shortcut,
+        _ShortcutIdentity((*_TOS, 'unbind'), '茶服解绑'): Lang.command.tos.unbind.shortcut,
+        _ShortcutIdentity((*_TOS, 'query'), '茶服查'): Lang.command.tos.query.shortcut,
+        _ShortcutIdentity((*_TOS, 'config'), '茶服配置'): Lang.command.tos.config.shortcut,
+    }
+)
+
+_LOCALES: Mapping[str, Locale] = MappingProxyType(
+    {
+        'en': 'en-US',
+        'en-us': 'en-US',
+        'zh': 'zh-CN',
+        'zh-cn': 'zh-CN',
+        'zh-hans': 'zh-CN',
+    }
+)
+
+
+def _locale(locale: str) -> Locale:
+    normalized = locale.strip().replace('_', '-').casefold()
+    return _LOCALES.get(normalized, 'en-US')
+
+
+def _is_production(path: Breadcrumb) -> bool:
+    return path[:1] == (_ROOT,)
+
+
+def _shortcut_item(
+    shortcut: 'HelpShortcut', locale: str | None = None
+) -> tuple[_ShortcutIdentity, LangItem, str] | None:
+    key = shortcut.key
+    target = tuple(shortcut.target)
+    for identity, item in _SHORTCUTS.items():
+        humanized_values = (identity.humanized, item(_locale(locale))) if locale is not None else (identity.humanized,)
+        for humanized in humanized_values:
+            if identity.target == target and (key == humanized or key.startswith(f'{humanized} ')):
+                return identity, item, humanized
+    return None
+
+
+def _missing_field(identity: _FieldIdentity, value: str | None) -> str | None:
+    if value is None or not _is_production(identity.breadcrumb) or identity in _FIELDS or identity in _FALLBACK_FIELDS:
+        return None
+    names = '/'.join(part for part in (identity.name, identity.arg_name) if part)
+    suffix = f':{names}' if names else ''
+    return f'{identity.kind}:{" / ".join(identity.breadcrumb)}{suffix}'
+
+
+def _missing_fields(node: 'HelpNode', path: Breadcrumb) -> list[str]:
+    identities = [(_FieldIdentity(path, 'description'), node.help_text)]
+    identities.extend((_FieldIdentity(path, 'arg', arg.name), arg.notice) for arg in node.args)
+    for option in node.options:
+        identities.append((_FieldIdentity(path, 'option', option.name), option.help_text))
+        identities.extend(
+            (_FieldIdentity(path, 'option_arg', option.name, arg.name), arg.notice) for arg in option.args
+        )
+
+    missing = [result for identity, value in identities if (result := _missing_field(identity, value)) is not None]
+    for child in node.subcommands:
+        missing.extend(_missing_fields(child, (*path, child.name)))
+    return missing
+
+
+def _missing_shortcut(shortcut: 'HelpShortcut', locale: str) -> str | None:
+    target = tuple(shortcut.target)
+    if not _is_production(target) or _shortcut_item(shortcut, locale) is not None:
+        return None
+    return f'shortcut:{" / ".join(target)}:{shortcut.key}'
+
+
+def validate_help_catalog(data: 'HelpData') -> None:
+    """Reject untranslated production metadata that has no canonical owner."""
+    missing = _missing_fields(data.command, tuple(data.breadcrumb))
+    missing.extend(
+        result for shortcut in data.shortcuts if (result := _missing_shortcut(shortcut, data.lang)) is not None
+    )
+    if missing:
+        message = f'Help catalog is missing identities: {", ".join(missing)}'
+        raise ValueError(message)
+
+
+def _text(identity: _FieldIdentity, fallback: str | None, locale: str) -> str | None:
+    item = _FIELDS.get(identity)
+    if item is not None:
+        return item(locale)
+    if fallback is None or not _is_production(identity.breadcrumb) or identity in _FALLBACK_FIELDS:
+        return fallback
+    message = f'Help catalog is missing identity: {identity!r}'
+    raise ValueError(message)
+
+
+def _arg(arg: 'HelpArg', path: Breadcrumb, locale: str, *, option: str = '') -> 'HelpArg':
+    from .render.schemas.help import HelpArg  # noqa: PLC0415
+
+    kind: FieldKind = 'option_arg' if option else 'arg'
+    return HelpArg(
+        name=arg.name,
+        notice=_text(_FieldIdentity(path, kind, option or arg.name, arg.name if option else ''), arg.notice, locale),
+        type_repr=arg.type_repr,
+        optional=arg.optional,
+        hidden=arg.hidden,
+        default=arg.default,
+    )
+
+
+def _option(option: 'HelpOption', path: Breadcrumb, locale: str) -> 'HelpOption':
+    from .render.schemas.help import HelpOption  # noqa: PLC0415
+
+    return HelpOption(
+        name=option.name,
+        aliases=list(option.aliases),
+        dest=option.dest,
+        args=[_arg(arg, path, locale, option=option.name) for arg in option.args],
+        help_text=_text(_FieldIdentity(path, 'option', option.name), option.help_text, locale),
+    )
+
+
+def _node(node: 'HelpNode', path: Breadcrumb, locale: str) -> 'HelpNode':
+    from .render.schemas.help import HelpNode  # noqa: PLC0415
+
+    return HelpNode(
+        name=node.name,
+        dest=node.dest,
+        aliases=list(node.aliases),
+        help_text=_text(_FieldIdentity(path, 'description'), node.help_text, locale),
+        args=[_arg(arg, path, locale) for arg in node.args],
+        options=[_option(option, path, locale) for option in node.options],
+        subcommands=[_node(child, (*path, child.name), locale) for child in node.subcommands],
+    )
+
+
+def _shortcut(shortcut: 'HelpShortcut', locale: str) -> 'HelpShortcut':
+    from .render.schemas.help import HelpShortcut  # noqa: PLC0415
+
+    binding = _shortcut_item(shortcut, locale)
+    if binding is None:
+        if _is_production(tuple(shortcut.target)):
+            message = f'Help catalog is missing shortcut identity: {shortcut!r}'
+            raise ValueError(message)
+        return HelpShortcut(key=shortcut.key, target=list(shortcut.target))
+    _, item, humanized = binding
+    key = f'{item(locale)}{shortcut.key[len(humanized) :]}'
+    return HelpShortcut(key=key, target=list(shortcut.target))
+
+
+def localize_help(data: 'HelpData', locale: str) -> 'HelpData':
+    """Return a translated copy of ``data`` for an explicit request locale."""
+    from .render.schemas.help import HelpData  # noqa: PLC0415
+
+    validate_help_catalog(data)
+
+    resolved_locale = _locale(locale)
+    path = tuple(data.breadcrumb)
+    return HelpData(
+        lang=resolved_locale,
+        command=_node(data.command, path, resolved_locale),
+        breadcrumb=list(data.breadcrumb),
+        usage=data.usage,
+        examples=list(data.examples),
+        shortcuts=[_shortcut(shortcut, resolved_locale) for shortcut in data.shortcuts],
+    )
+
+
+__all__ = ['localize_help', 'validate_help_catalog']

--- a/nonebot_plugin_tetris_stats/utils/help_formatter.py
+++ b/nonebot_plugin_tetris_stats/utils/help_formatter.py
@@ -188,7 +188,11 @@ def _collect_shortcuts(root: Alconna) -> list[tuple[str, list[str]]]:
             results.append((key, [root_canonical]))
             continue
         cmd_text = _extract_command_text(short.command)
-        target = [tok for tok in cmd_text.split() if _is_path_segment(tok)] if cmd_text else [root_canonical]
+        path_tokens = [tok for tok in cmd_text.split() if _is_path_segment(tok)] if cmd_text else []
+        chain = _resolve_current_subcommand(root, path_tokens[1:]) if path_tokens else None
+        target = (
+            [root_canonical, *(_split_name(sub.name)[0] for sub in chain)] if chain is not None else [root_canonical]
+        )
         suffix = _render_target_signature(root, target)
         rendered = f'{key} {suffix}' if suffix else key
         results.append((rendered, target))
@@ -291,8 +295,9 @@ class StructuredHelpFormatter(TextFormatter):
             root_canonical, _ = _split_name(self.root.header_display)
             breadcrumb = [root_canonical, *(_split_name(s.name)[0] for s in chain)]
 
-        # Lazy import avoids circular dependency with games/* (render/__init__.py
-        # -> host.py -> games.tetrio.api.cache -> back into games/__init__.py).
+        # Lazy imports avoid circular dependencies with games/*
+        # (render/__init__.py -> host.py -> games.tetrio.api.cache).
+        from .help_catalog import localize_help  # noqa: PLC0415
         from .lang import get_lang  # noqa: PLC0415
 
         node = HelpNode(
@@ -318,12 +323,14 @@ class StructuredHelpFormatter(TextFormatter):
             shortcuts = [
                 HelpShortcut(key=k, target=t) for k, t in all_shortcuts if t[1 : len(breadcrumb)] == breadcrumb[1:]
             ]
+        locale = get_lang()
         data = HelpData(
-            lang=get_lang(),
+            lang=locale,
             command=node,
             breadcrumb=breadcrumb,
             usage=usage,
             examples=examples,
             shortcuts=shortcuts,
         )
+        data = localize_help(data, locale)
         return data.model_dump_json(by_alias=True) if PYDANTIC_V2 else data.json(by_alias=True)

--- a/nonebot_plugin_tetris_stats/utils/lang.py
+++ b/nonebot_plugin_tetris_stats/utils/lang.py
@@ -1,8 +1,23 @@
-from typing import cast
+from typing import NamedTuple, cast
 
 from ..i18n import Lang
 from .typedefs import Lang as LangType
 
 
+class UnbindChoices(NamedTuple):
+    yes: str
+    no: str
+
+    def is_cancelled(self, response: str | None) -> bool:
+        return response is None or response == self.no
+
+
 def get_lang() -> LangType:
     return cast('LangType', Lang.template.template_language())
+
+
+def get_unbind_choices(locale: str | None = None) -> UnbindChoices:
+    return UnbindChoices(
+        yes=Lang.bind.confirm_yes(locale),
+        no=Lang.bind.confirm_no(locale),
+    )

--- a/nonebot_plugin_tetris_stats/utils/request.py
+++ b/nonebot_plugin_tetris_stats/utils/request.py
@@ -11,6 +11,7 @@ from playwright.async_api import Response
 from yarl import URL
 
 from ..config.config import CACHE_PATH, config
+from ..i18n import Lang
 from .browser import BrowserManager
 from .exception import RequestError
 
@@ -92,8 +93,7 @@ class AntiCloudflare:
                     await page.wait_for_timeout(1000)
                 else:
                     if not isinstance(response, Response):
-                        msg = 'api请求失败'
-                        raise RequestError(msg)
+                        raise RequestError(Lang.error.RequestError.request.api)
                     self.headers = await response.request.all_headers()
                     try:
                         self.cookies = {
@@ -104,8 +104,7 @@ class AntiCloudflare:
                     except KeyError:
                         self.cookies = None
                     return await response.body()
-        msg = '绕过五秒盾失败'
-        raise RequestError(msg)
+        raise RequestError(Lang.error.RequestError.request.cloudflare)
 
 
 class Request:
@@ -140,15 +139,16 @@ class Request:
         try:
             response = await self.client.get(str(url), cookies=cookies, headers=headers)
             if response.status_code != HTTPStatus.OK:
-                msg = (
-                    f'请求错误 code: {response.status_code} {HTTPStatus(response.status_code).phrase}\n{response.text}'
+                raise RequestError(
+                    Lang.error.RequestError.request.response,
+                    status_code=response.status_code,
+                    reason=HTTPStatus(response.status_code).phrase,
+                    body=response.text,
                 )
-                raise RequestError(msg, status_code=response.status_code)
             if is_json:
                 decoder.decode(response.content)
         except HTTPError as e:
-            msg = f'请求错误 \n{e!r}'
-            raise RequestError(msg) from e
+            raise RequestError(Lang.error.RequestError.request.transport, detail=repr(e)) from e
         except DecodeError:  # 由于捕获的是 DecodeError 所以一定是 is_json = True
             if enable_anti_cloudflare and url.host is not None:
                 return await self.anti_cloudflares.setdefault(url.host, AntiCloudflare(url.host))(str(url), self.proxy)
@@ -183,5 +183,4 @@ class Request:
                 else:
                     raise
                 continue
-        msg = f'所有地址皆不可用\n{error_list!r}'
-        raise RequestError(msg)
+        raise RequestError(Lang.error.RequestError.request.failover, errors=error_list)

--- a/nonebot_plugin_tetris_stats/utils/retry.py
+++ b/nonebot_plugin_tetris_stats/utils/retry.py
@@ -7,6 +7,7 @@ from typing import Any, ParamSpec, TypeVar
 
 from nonebot.log import logger
 from nonebot_plugin_alconna.uniseg import SerializeFailed, UniMessage
+from tarina.lang.model import LangItem
 
 from ..i18n import Lang
 
@@ -18,7 +19,7 @@ def retry(
     max_attempts: int = 3,
     exception_type: type[BaseException] | tuple[type[BaseException], ...] = Exception,
     delay: timedelta | None = None,
-    reply: str | UniMessage | None = None,
+    reply: str | LangItem | UniMessage | None = None,
 ) -> Callable[[Callable[P, Coroutine[Any, Any, T]]], Callable[P, Coroutine[Any, Any, T]]]:
     def decorator(func: Callable[P, Coroutine[Any, Any, T]]) -> Callable[P, Coroutine[Any, Any, T]]:
         @wraps(func)
@@ -27,8 +28,9 @@ def retry(
                 if i > 0:
                     message = Lang.retry.message(func=func.__name__, i=i, max_attempts=max_attempts)
                     logger.debug(message)
+                    retry_reply = reply() if isinstance(reply, LangItem) else reply
                     with suppress(SerializeFailed):
-                        await UniMessage(reply or message).send()
+                        await UniMessage(retry_reply if retry_reply is not None else message).send()
                 if i == max_attempts:
                     break
                 try:

--- a/nonebot_plugin_tetris_stats/utils/screenshot.py
+++ b/nonebot_plugin_tetris_stats/utils/screenshot.py
@@ -1,6 +1,7 @@
 from playwright.async_api import BrowserContext, TimeoutError, ViewportSize  # noqa: A004
 
 from ..config.config import config
+from ..i18n import Lang
 from .browser import BrowserManager
 from .retry import retry
 from .time_it import time_it
@@ -10,7 +11,7 @@ async def context_factory() -> BrowserContext:
     return await (await BrowserManager.get_browser()).new_context(device_scale_factor=config.tetris.screenshot_quality)
 
 
-@retry(exception_type=TimeoutError, reply='截图失败, 重试中')
+@retry(exception_type=TimeoutError, reply=Lang.retry.screenshot)
 @time_it
 async def screenshot(url: str) -> bytes:
     context = await BrowserManager.get_context('screenshot', factory=context_factory)

--- a/nonebot_plugin_tetris_stats/utils/typedefs.py
+++ b/nonebot_plugin_tetris_stats/utils/typedefs.py
@@ -73,4 +73,4 @@ Me: TypeAlias = Literal[
     'oneself',
 ]
 
-Lang: TypeAlias = Literal['zh-CN', 'en-US']
+Lang: TypeAlias = Literal['zh-CN', 'zh-TW', 'en-US', 'es-ES', 'ja-JP', 'ko-KR']

--- a/tests/test_help_formatter.py
+++ b/tests/test_help_formatter.py
@@ -87,6 +87,176 @@ def test_deep_subcommand(alc: Alconna) -> None:
     assert [a.name for a in data.command.args] == ['account']  # noqa: S101
 
 
+def test_production_help_is_request_local_and_does_not_mutate_tree(monkeypatch: pytest.MonkeyPatch) -> None:
+    from arclet.alconna import Option  # noqa: PLC0415
+
+    from nonebot_plugin_tetris_stats.games import command  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils import lang  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils.help_formatter import _resolve_current_subcommand  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
+
+    query = _resolve_current_subcommand(command, ['TETR.IO', 'query'])
+    assert query is not None  # noqa: S101
+    query_node = query[-1]
+    compare = next(option for option in query_node.options if isinstance(option, Option) and option.name == '--compare')
+    who = query_node.args.argument[0]
+    compare_arg = compare.args.argument[0]
+    shortcuts_before = tuple(command_manager.get_shortcut(command))
+    metadata_before = (query_node.help_text, who.notice, compare.help_text, compare_arg.notice)
+
+    monkeypatch.setattr(lang, 'get_lang', lambda: 'zh-CN')
+    zh_root = HelpData.model_validate_json(command.formatter.format_node())
+    zh = HelpData.model_validate_json(command.formatter.format_node(['TETR.IO', 'query']))
+
+    monkeypatch.setattr(lang, 'get_lang', lambda: 'en-US')
+    en_root = HelpData.model_validate_json(command.formatter.format_node())
+    en = HelpData.model_validate_json(command.formatter.format_node(['TETR.IO', 'query']))
+
+    assert zh_root.command.help_text == '俄罗斯方块相关游戏数据查询'  # noqa: S101
+    assert en_root.command.help_text == 'Query player data for Tetris-related games'  # noqa: S101
+    assert zh.breadcrumb == en.breadcrumb == ['tetris-stats', 'TETR.IO', 'query']  # noqa: S101
+    assert zh.command.help_text == '查询 TETR.IO 游戏信息'  # noqa: S101
+    assert en.command.help_text == 'Query TETR.IO game information'  # noqa: S101
+    assert zh.command.args[0].notice == '@想要查询的人 / 自己 / TETR.IO 用户名 / ID'  # noqa: S101
+    assert en.command.args[0].notice == '@person to query / me / TETR.IO username / ID'  # noqa: S101
+    zh_compare = next(option for option in zh.command.options if option.name == '--compare')
+    en_compare = next(option for option in en.command.options if option.name == '--compare')
+    assert zh_compare.help_text == '指定对比时间距离'  # noqa: S101
+    assert en_compare.help_text == 'Specify a comparison time span'  # noqa: S101
+    assert zh_compare.args[0].notice == '对比时间距离 (如 7d, 2w, 24h)'  # noqa: S101
+    assert en_compare.args[0].notice == 'Comparison time span (e.g. 7d, 2w, 24h)'  # noqa: S101
+    assert any(shortcut.key.startswith('io查 ') for shortcut in zh.shortcuts)  # noqa: S101
+    assert any(shortcut.key.startswith('ioquery ') for shortcut in en.shortcuts)  # noqa: S101
+    assert (  # noqa: S101
+        query_node.help_text,
+        who.notice,
+        compare.help_text,
+        compare_arg.notice,
+    ) == metadata_before
+    assert tuple(command_manager.get_shortcut(command)) == shortcuts_before  # noqa: S101
+
+
+def test_production_help_catalog_is_complete() -> None:
+    from nonebot_plugin_tetris_stats.games import command  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils.help_catalog import validate_help_catalog  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
+
+    data = HelpData.model_validate_json(command.formatter.format_node())
+
+    validate_help_catalog(data)
+
+
+def test_help_catalog_rejects_unregistered_production_metadata() -> None:
+    from nonebot_plugin_tetris_stats.utils.help_catalog import validate_help_catalog  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData, HelpNode  # noqa: PLC0415
+
+    data = HelpData(
+        lang='zh-CN',
+        command=HelpNode(
+            name='missing',
+            dest='missing',
+            aliases=[],
+            help_text='未登记的说明',
+            args=[],
+            options=[],
+            subcommands=[],
+        ),
+        breadcrumb=['tetris-stats', 'missing'],
+    )
+
+    with pytest.raises(ValueError, match=r'description.*tetris-stats.*missing'):
+        validate_help_catalog(data)
+
+
+def test_every_english_shortcut_is_displayed_and_matches(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nonebot_plugin_tetris_stats.games import command  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils import lang  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
+
+    cases = (
+        ('iobind', 'iobind testuser', 'TETRIO.bind'),
+        ('ioconfig', 'ioconfig', 'TETRIO.config'),
+        ('ioquery', 'ioquery me', 'TETRIO.query'),
+        ('iorank', 'iorank', 'TETRIO.rank'),
+        ('iorecordblitz', 'iorecordblitz me', 'TETRIO.record'),
+        ('iorecord40l', 'iorecord40l me', 'TETRIO.record'),
+        ('iounbind', 'iounbind', 'TETRIO.unbind'),
+        ('ioverify', 'ioverify', 'TETRIO.verify'),
+        ('topbind', 'topbind testuser', 'TOP.bind'),
+        ('topunbind', 'topunbind', 'TOP.unbind'),
+        ('topquery', 'topquery me', 'TOP.query'),
+        ('topconfig', 'topconfig', 'TOP.config'),
+        ('tosbind', 'tosbind testuser', 'TOS.bind'),
+        ('tosunbind', 'tosunbind', 'TOS.unbind'),
+        ('tosquery', 'tosquery me', 'TOS.query'),
+        ('tosconfig', 'tosconfig', 'TOS.config'),
+    )
+    monkeypatch.setattr(lang, 'get_lang', lambda: 'en-US')
+    help_data = HelpData.model_validate_json(command.formatter.format_node())
+    displayed = {shortcut.key for shortcut in help_data.shortcuts}
+
+    for humanized, trigger, target in cases:
+        assert any(key == humanized or key.startswith(f'{humanized} ') for key in displayed), humanized  # noqa: S101
+        result = command.parse(trigger)
+        assert result.matched, trigger  # noqa: S101
+        assert result.find(target), (trigger, target)  # noqa: S101
+
+
+def test_future_option_catalog_entries_apply_when_the_fields_exist() -> None:
+    from nonebot_plugin_tetris_stats.utils.help_catalog import localize_help  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils.render.schemas.help import (  # noqa: PLC0415
+        HelpArg,
+        HelpData,
+        HelpNode,
+        HelpOption,
+    )
+
+    def arg(name: str) -> HelpArg:
+        return HelpArg(name=name, notice=None, type_repr='str', optional=False, hidden=False, default=None)
+
+    def data(node: str, options: list[HelpOption]) -> HelpData:
+        return HelpData(
+            lang='zh-CN',
+            command=HelpNode(
+                name=node,
+                dest=node,
+                aliases=[],
+                help_text=None,
+                args=[],
+                options=options,
+                subcommands=[],
+            ),
+            breadcrumb=['tetris-stats', 'TETR.IO', node],
+        )
+
+    localized_list = localize_help(
+        data(
+            'list',
+            [HelpOption(name='--sort', aliases=[], dest='sort', args=[arg('sort')], help_text=None)],
+        ),
+        'en-US',
+    )
+    sort = localized_list.command.options[0]
+    assert sort.help_text == 'Ranking metric'  # noqa: S101
+    assert sort.args[0].notice == 'Ranking metric (league, pps, apm, adpm, apl, or adpl)'  # noqa: S101
+
+    localized_record = localize_help(
+        data(
+            'record',
+            [
+                HelpOption(name='--type', aliases=[], dest='type', args=[arg('record_type')], help_text=None),
+                HelpOption(name='--index', aliases=[], dest='index', args=[arg('index')], help_text=None),
+            ],
+        ),
+        'zh-CN',
+    )
+    record_type, index = localized_record.command.options
+    assert record_type.help_text == '记录类型'  # noqa: S101
+    assert record_type.args[0].notice == '记录类型 (top、recent、progression)'  # noqa: S101
+    assert index.help_text == '记录序号'  # noqa: S101
+    assert index.args[0].notice == '记录序号'  # noqa: S101
+
+
 def test_args_metadata() -> None:
     from nonebot_plugin_tetris_stats.utils.help_formatter import StructuredHelpFormatter  # noqa: PLC0415
     from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415

--- a/tests/test_help_formatter.py
+++ b/tests/test_help_formatter.py
@@ -47,6 +47,29 @@ def _capture(alc: Alconna, cmd: str) -> str:
     return out
 
 
+@pytest.mark.parametrize('locale', ['zh-CN', 'zh-TW', 'en-US', 'es-ES', 'ja-JP', 'ko-KR'])
+def test_help_schema_accepts_supported_locales(locale: str) -> None:
+    from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
+
+    data = HelpData.model_validate(
+        {
+            'lang': locale,
+            'command': {
+                'name': 'tstats',
+                'dest': 'tstats',
+                'aliases': [],
+                'help_text': None,
+                'args': [],
+                'options': [],
+                'subcommands': [],
+            },
+            'breadcrumb': ['tstats'],
+        }
+    )
+
+    assert data.lang == locale  # noqa: S101
+
+
 def test_root_node_metadata(alc: Alconna) -> None:
     from nonebot_plugin_tetris_stats.utils.render.schemas.help import HelpData  # noqa: PLC0415
 

--- a/tests/test_runtime_i18n.py
+++ b/tests/test_runtime_i18n.py
@@ -1,41 +1,4 @@
-import json
-from pathlib import Path
-from string import Formatter
-from typing import cast
-
 import pytest
-
-
-def _flatten_resource(value: object, prefix: tuple[str, ...] = ()) -> dict[tuple[str, ...], str]:
-    data = cast('dict[str, object]', value)
-    flattened: dict[tuple[str, ...], str] = {}
-    for key, item in data.items():
-        item_path = (*prefix, key)
-        if isinstance(item, dict):
-            flattened.update(_flatten_resource(item, item_path))
-            continue
-        assert isinstance(item, str), '.lang.json leaves must be strings'  # noqa: S101
-        flattened[item_path] = item
-    return flattened
-
-
-def _placeholders(message: str) -> set[str]:
-    return {field_name for _, field_name, _, _ in Formatter().parse(message) if field_name is not None}
-
-
-def test_every_locale_matches_the_canonical_resource_contract() -> None:
-    resource_dir = Path(__file__).parents[1] / 'nonebot_plugin_tetris_stats' / 'i18n'
-    resources = sorted(path for path in resource_dir.glob('*.json') if not path.name.startswith('.'))
-    canonical = _flatten_resource(json.loads((resource_dir / 'en-US.json').read_text()))
-
-    for resource in resources:
-        localized = _flatten_resource(json.loads(resource.read_text()))
-        assert localized.keys() == canonical.keys(), resource.name  # noqa: S101
-        for key, canonical_message in canonical.items():
-            assert _placeholders(localized[key]) == _placeholders(canonical_message), (  # noqa: S101
-                resource.name,
-                '.'.join(key),
-            )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_runtime_i18n.py
+++ b/tests/test_runtime_i18n.py
@@ -1,0 +1,95 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    ('locale', 'expected'),
+    [
+        ('zh-CN', ('用户名/ID不合法', '用户名不合法', '用户名/ID不合法', '时间格式不正确')),
+        (
+            'en-US',
+            ('Username/ID is invalid', 'Username is invalid', 'Username/ID is invalid', 'Invalid duration format'),
+        ),
+    ],
+)
+def test_parser_errors_follow_locale(locale: str, expected: tuple[str, str, str, str]) -> None:
+    from nonebot_plugin_tetris_stats.games.tetrio import get_player as get_tetrio_player  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.games.top import get_player as get_top_player  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.games.tos import get_player as get_tos_player  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils.duration import parse_duration  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils.exception import MessageFormatError  # noqa: PLC0415
+
+    errors: list[MessageFormatError] = []
+    for parser in (get_tetrio_player, get_top_player, get_tos_player):
+        with pytest.raises(MessageFormatError) as exc_info:
+            parser('!')
+        errors.append(exc_info.value)
+
+    duration_error = parse_duration('invalid')
+    assert isinstance(duration_error, MessageFormatError)  # noqa: S101
+    errors.append(duration_error)
+
+    assert tuple(error.render(locale) for error in errors) == expected  # noqa: S101
+
+
+def test_request_error_is_rendered_lazily_without_losing_detail() -> None:
+    from nonebot_plugin_tetris_stats.i18n import Lang  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils.exception import RequestError  # noqa: PLC0415
+
+    error = RequestError(Lang.error.RequestError.request.transport, detail="ConnectError('socket reset')")
+
+    assert error.render('zh-CN') == "请求错误\nConnectError('socket reset')"  # noqa: S101
+    assert error.render('en-US') == "Request error\nConnectError('socket reset')"  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    ('locale', 'expected'),
+    [
+        ('zh-CN', ('是', '否')),
+        ('en-US', ('Yes', 'No')),
+    ],
+)
+def test_unbind_choices_share_display_and_cancellation(locale: str, expected: tuple[str, str]) -> None:
+    from nonebot_plugin_tetris_stats.utils.lang import get_unbind_choices  # noqa: PLC0415
+
+    choices = get_unbind_choices(locale)
+
+    assert tuple(choices) == expected  # noqa: S101
+    assert choices.is_cancelled(None)  # noqa: S101
+    assert choices.is_cancelled(expected[1])  # noqa: S101
+    assert not choices.is_cancelled(expected[0])  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_screenshot_retry_reply_is_resolved_for_each_invocation(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nonebot_plugin_alconna.uniseg import UniMessage  # noqa: PLC0415
+    from tarina.lang import lang  # type: ignore[import-untyped]  # noqa: PLC0415
+
+    from nonebot_plugin_tetris_stats.i18n import Lang  # noqa: PLC0415
+    from nonebot_plugin_tetris_stats.utils.retry import retry  # noqa: PLC0415
+
+    attempts = 0
+    sent: list[str] = []
+
+    async def capture_send(message: UniMessage) -> None:
+        sent.append(message.extract_plain_text())
+
+    monkeypatch.setattr(UniMessage, 'send', capture_send)
+
+    @retry(max_attempts=2, exception_type=RuntimeError, reply=Lang.retry.screenshot)
+    async def flaky_screenshot() -> bytes:
+        nonlocal attempts
+        attempts += 1
+        if attempts % 2 == 1:
+            raise RuntimeError
+        return b'image'
+
+    original_locale = lang.current
+    try:
+        lang.select('zh-CN')
+        assert await flaky_screenshot() == b'image'  # noqa: S101
+        lang.select('en-US')
+        assert await flaky_screenshot() == b'image'  # noqa: S101
+    finally:
+        lang.select(original_locale)
+
+    assert sent == ['截图失败\uff0c正在重试', 'Screenshot failed, retrying']  # noqa: S101

--- a/tests/test_runtime_i18n.py
+++ b/tests/test_runtime_i18n.py
@@ -1,4 +1,49 @@
+import json
+from pathlib import Path
+from string import Formatter
+from typing import cast
+
 import pytest
+
+
+def _flatten_resource(
+    value: object, prefix: tuple[str, ...] = ()
+) -> dict[tuple[str, ...], str]:
+    data = cast('dict[str, object]', value)
+    flattened: dict[tuple[str, ...], str] = {}
+    for key, item in data.items():
+        item_path = (*prefix, key)
+        if isinstance(item, dict):
+            flattened.update(_flatten_resource(item, item_path))
+            continue
+        assert isinstance(item, str), '.lang.json leaves must be strings'  # noqa: S101
+        flattened[item_path] = item
+    return flattened
+
+
+def _placeholders(message: str) -> set[str]:
+    return {
+        field_name
+        for _, field_name, _, _ in Formatter().parse(message)
+        if field_name is not None
+    }
+
+
+def test_every_locale_matches_the_canonical_resource_contract() -> None:
+    resource_dir = Path(__file__).parents[1] / 'nonebot_plugin_tetris_stats' / 'i18n'
+    resources = sorted(
+        path for path in resource_dir.glob('*.json') if not path.name.startswith('.')
+    )
+    canonical = _flatten_resource(json.loads((resource_dir / 'en-US.json').read_text()))
+
+    for resource in resources:
+        localized = _flatten_resource(json.loads(resource.read_text()))
+        assert localized.keys() == canonical.keys(), resource.name  # noqa: S101
+        for key, canonical_message in canonical.items():
+            assert _placeholders(localized[key]) == _placeholders(canonical_message), (  # noqa: S101
+                resource.name,
+                '.'.join(key),
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_runtime_i18n.py
+++ b/tests/test_runtime_i18n.py
@@ -6,9 +6,7 @@ from typing import cast
 import pytest
 
 
-def _flatten_resource(
-    value: object, prefix: tuple[str, ...] = ()
-) -> dict[tuple[str, ...], str]:
+def _flatten_resource(value: object, prefix: tuple[str, ...] = ()) -> dict[tuple[str, ...], str]:
     data = cast('dict[str, object]', value)
     flattened: dict[tuple[str, ...], str] = {}
     for key, item in data.items():
@@ -22,18 +20,12 @@ def _flatten_resource(
 
 
 def _placeholders(message: str) -> set[str]:
-    return {
-        field_name
-        for _, field_name, _, _ in Formatter().parse(message)
-        if field_name is not None
-    }
+    return {field_name for _, field_name, _, _ in Formatter().parse(message) if field_name is not None}
 
 
 def test_every_locale_matches_the_canonical_resource_contract() -> None:
     resource_dir = Path(__file__).parents[1] / 'nonebot_plugin_tetris_stats' / 'i18n'
-    resources = sorted(
-        path for path in resource_dir.glob('*.json') if not path.name.startswith('.')
-    )
+    resources = sorted(path for path in resource_dir.glob('*.json') if not path.name.startswith('.'))
     canonical = _flatten_resource(json.loads((resource_dir / 'en-US.json').read_text()))
 
     for resource in resources:

--- a/tests/tetrio/test_bind.py
+++ b/tests/tetrio/test_bind.py
@@ -6,13 +6,24 @@ from tests.fake_event import FakeGroupMessageEvent
 
 
 @pytest.mark.asyncio
-async def test_invalid_name(app: App) -> None:
+@pytest.mark.parametrize(
+    ('locale', 'expected'),
+    [('zh-CN', '用户名/ID不合法'), ('en-US', 'Username/ID is invalid')],
+)
+async def test_invalid_name(app: App, locale: str, expected: str) -> None:
+    from tarina.lang import lang  # type: ignore[import-untyped]  # noqa: PLC0415
+
     from nonebot_plugin_tetris_stats.games import alc  # noqa: PLC0415
 
-    raw_message = 'tstats tetrio bind 芜湖'
-    message = Message(raw_message)
-    event = FakeGroupMessageEvent(message=message, original_message=message, raw_message=raw_message)
-    async with app.test_matcher(alc) as ctx:
-        bot = ctx.create_bot()
-        ctx.receive_event(bot, event)
-        ctx.should_call_send(event, '用户名/ID不合法', result=None)
+    original_locale = lang.current
+    try:
+        lang.select(locale)
+        raw_message = 'tstats tetrio bind 芜湖'
+        message = Message(raw_message)
+        event = FakeGroupMessageEvent(message=message, original_message=message, raw_message=raw_message)
+        async with app.test_matcher(alc) as ctx:
+            bot = ctx.create_bot()
+            ctx.receive_event(bot, event)
+            ctx.should_call_send(event, expected, result=None)
+    finally:
+        lang.select(original_locale)


### PR DESCRIPTION
## 运行时消息

- 解析、duration、HTTP/Cloudflare/failover 与游戏 API 错误按请求 locale 延迟渲染
- 保留 status、reason、body、exception repr 和 API detail
- 三个平台解绑确认共享强类型 yes/no owner
- 国际化 TOS 解绑、绑定图片提示与 screenshot retry

## 命令帮助

- immutable help catalog 按 canonical identity 覆盖 HelpData，不 mutate 全局命令树
- catalog 直接引用生成的强类型 `Lang.command.*`，不再使用裸翻译 key
- 完整性校验遍历真实生产帮助树；遗漏绑定时响亮失败，不静默夹杂中文
- 英文 shortcut humanized 使用现有 regex 真正可执行的紧凑输入，并有解析回归
- #452 `--sort` 与 #345 `--type/--index` 仍作为同批真实 PR 的组合合同预置
- 两处 Tarina `type: ignore[import-untyped]` 仅隔离无 `py.typed` 的第三方测试边界

Closes #410

## 验证

- help/runtime/bind：20 passed
- Ruff：通过
- Mypy：151 source files 通过
- BasedPyright：0 errors
- `uv build`：sdist + wheel